### PR TITLE
Added more android toolchains

### DIFF
--- a/android-ndk-r10e-api-16-armeabi-v7a-neon-clang-35.cmake
+++ b/android-ndk-r10e-api-16-armeabi-v7a-neon-clang-35.cmake
@@ -1,0 +1,31 @@
+# Copyright (c) 2015, Ruslan Baratov
+# Copyright (c) 2015, David Hirvonen
+# All rights reserved.
+
+if(DEFINED POLLY_ANDROID_NDK_R10E_API_16_ARMEABI_V7A_NEON_CLANG_35_CMAKE_)
+  return()
+else()
+  set(POLLY_ANDROID_NDK_R10E_API_16_ARMEABI_V7A_NEON_CLANG_35_CMAKE_ 1)
+endif()
+
+include("${CMAKE_CURRENT_LIST_DIR}/utilities/polly_clear_environment_variables.cmake")
+
+include("${CMAKE_CURRENT_LIST_DIR}/utilities/polly_init.cmake")
+
+set(ANDROID_NDK_VERSION "r10e")
+set(ANDROID_NATIVE_API_LEVEL "16")
+set(ANDROID_ABI "armeabi-v7a with NEON")
+set(ANDROIR_TOOLCHAIN_NAME "arm-linux-androideabi-clang3.5")
+
+polly_init(
+    "Android NDK ${ANDROID_NDK_VERSION} / \
+API ${ANDROID_NATIVE_API_LEVEL} / ${ANDROID_ABI} / \
+c++11 support"
+    "Unix Makefiles"
+)
+
+include("${CMAKE_CURRENT_LIST_DIR}/utilities/polly_common.cmake")
+
+include("${CMAKE_CURRENT_LIST_DIR}/flags/cxx11.cmake") # before toolchain!
+
+include("${CMAKE_CURRENT_LIST_DIR}/os/android.cmake")

--- a/android-ndk-r10e-api-16-armeabi-v7a-neon.cmake
+++ b/android-ndk-r10e-api-16-armeabi-v7a-neon.cmake
@@ -1,0 +1,30 @@
+# Copyright (c) 2015, Ruslan Baratov
+# Copyright (c) 2015, David Hirvonen
+# All rights reserved.
+
+if(DEFINED POLLY_ANDROID_NDK_R10E_API_16_ARMEABI_V7A_NEON_CMAKE_)
+  return()
+else()
+  set(POLLY_ANDROID_NDK_R10E_API_16_ARMEABI_V7A_NEON_CMAKE_ 1)
+endif()
+
+include("${CMAKE_CURRENT_LIST_DIR}/utilities/polly_clear_environment_variables.cmake")
+
+include("${CMAKE_CURRENT_LIST_DIR}/utilities/polly_init.cmake")
+
+set(ANDROID_NDK_VERSION "r10e")
+set(ANDROID_NATIVE_API_LEVEL "16")
+set(ANDROID_ABI "armeabi-v7a with NEON")
+
+polly_init(
+    "Android NDK ${ANDROID_NDK_VERSION} / \
+API ${ANDROID_NATIVE_API_LEVEL} / ${ANDROID_ABI} / \
+c++11 support"
+    "Unix Makefiles"
+)
+
+include("${CMAKE_CURRENT_LIST_DIR}/utilities/polly_common.cmake")
+
+include("${CMAKE_CURRENT_LIST_DIR}/flags/cxx11.cmake") # before toolchain!
+
+include("${CMAKE_CURRENT_LIST_DIR}/os/android.cmake")

--- a/android-ndk-r10e-api-21-arm64-v8a-clang-35.cmake
+++ b/android-ndk-r10e-api-21-arm64-v8a-clang-35.cmake
@@ -1,0 +1,31 @@
+# Copyright (c) 2015, Ruslan Baratov
+# Copyright (c) 2015, David Hirvonen
+# All rights reserved.
+
+if(DEFINED POLLY_ANDROID_NDK_R10E_API_21_ARM64_V8A_CLANG_35_CMAKE_)
+  return()
+else()
+  set(POLLY_ANDROID_NDK_R10E_API_21_ARM64_V8A_CLANG_35_CMAKE_ 1)
+endif()
+
+include("${CMAKE_CURRENT_LIST_DIR}/utilities/polly_clear_environment_variables.cmake")
+
+include("${CMAKE_CURRENT_LIST_DIR}/utilities/polly_init.cmake")
+
+set(ANDROID_NDK_VERSION "r10e")
+set(ANDROID_NATIVE_API_LEVEL "21")
+set(ANDROID_ABI "arm64-v8a")
+set(ANDROID_TOOLCHAIN_NAME "aarch64-linux-android-clang3.5")
+
+polly_init(
+    "Android NDK ${ANDROID_NDK_VERSION} / \
+API ${ANDROID_NATIVE_API_LEVEL} / ${ANDROID_ABI} / \
+c++11 support"
+    "Unix Makefiles"
+)
+
+include("${CMAKE_CURRENT_LIST_DIR}/utilities/polly_common.cmake")
+
+include("${CMAKE_CURRENT_LIST_DIR}/flags/cxx11.cmake") # before toolchain!
+
+include("${CMAKE_CURRENT_LIST_DIR}/os/android.cmake")

--- a/android-ndk-r10e-api-21-arm64-v8a-gcc-49.cmake
+++ b/android-ndk-r10e-api-21-arm64-v8a-gcc-49.cmake
@@ -1,0 +1,31 @@
+# Copyright (c) 2015, Ruslan Baratov
+# Copyright (c) 2015, David Hirvonen
+# All rights reserved.
+
+if(DEFINED POLLY_ANDROID_NDK_R10E_API_21_ARM64_V8A_GCC_49_CMAKE_)
+  return()
+else()
+  set(POLLY_ANDROID_NDK_R10E_API_21_ARM64_V8A_GCC_49_CMAKE_ 1)
+endif()
+
+include("${CMAKE_CURRENT_LIST_DIR}/utilities/polly_clear_environment_variables.cmake")
+
+include("${CMAKE_CURRENT_LIST_DIR}/utilities/polly_init.cmake")
+
+set(ANDROID_NDK_VERSION "r10e")
+set(ANDROID_NATIVE_API_LEVEL "21")
+set(ANDROID_ABI "arm64-v8a")
+set(ANDROID_TOOLCHAIN_NAME "aarch64-linux-android-4.9")
+
+polly_init(
+    "Android NDK ${ANDROID_NDK_VERSION} / \
+API ${ANDROID_NATIVE_API_LEVEL} / ${ANDROID_ABI} / \
+c++11 support"
+    "Unix Makefiles"
+)
+
+include("${CMAKE_CURRENT_LIST_DIR}/utilities/polly_common.cmake")
+
+include("${CMAKE_CURRENT_LIST_DIR}/flags/cxx11.cmake") # before toolchain!
+
+include("${CMAKE_CURRENT_LIST_DIR}/os/android.cmake")

--- a/android-ndk-r10e-api-21-armeabi-v7a-neon-clang-35.cmake
+++ b/android-ndk-r10e-api-21-armeabi-v7a-neon-clang-35.cmake
@@ -1,0 +1,29 @@
+# Copyright (c) 2015, Ruslan Baratov
+# Copyright (c) 2015, David Hirvonen
+# All rights reserved.
+
+if(DEFINED POLLY_ANDROID_NDK_R10E_API_21_ARMEABI_V7A_NEON_CLANG_35_CMAKE_)
+  return()
+else()
+  set(POLLY_ANDROID_NDK_R10E_API_21_ARMEABI_V7A_NEON_CLANG_35_CMAKE_ 1)
+endif()
+
+include("${CMAKE_CURRENT_LIST_DIR}/utilities/polly_clear_environment_variables.cmake")
+
+include("${CMAKE_CURRENT_LIST_DIR}/utilities/polly_init.cmake")
+
+set(ANDROID_NDK_VERSION "r10e")
+set(ANDROID_NATIVE_API_LEVEL "21")
+set(ANDROID_ABI "armeabi-v7a with NEON")
+set(ANDROID_TOOLCHAIN_NAME "arm-linux-androideabi-clang3.5")
+
+polly_init(
+    "Android NDK ${ANDROID_NDK_VERSION} / \
+API ${ANDROID_NATIVE_API_LEVEL} / ${ANDROID_ABI} / ${ANDROID_STL} / ${ANDROID_TOOLCHAIN_NAME} \
+c++11 support"
+    "Unix Makefiles"
+)
+
+include("${CMAKE_CURRENT_LIST_DIR}/utilities/polly_common.cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/flags/cxx11.cmake") # before toolchain!
+include("${CMAKE_CURRENT_LIST_DIR}/os/android.cmake")

--- a/bin/detail/toolchain_table.py
+++ b/bin/detail/toolchain_table.py
@@ -45,11 +45,16 @@ class Toolchain:
 
 toolchain_table = [
     Toolchain('default', ''),
-    Toolchain('android-ndk-r10e-api-21-arm64-v8a', 'Unix Makefiles'),
-    Toolchain('android-ndk-r10e-api-21-armeabi-v7a-neon', 'Unix Makefiles'),
+    Toolchain('android-ndk-r10e-api-16-armeabi-v7a-neon', 'Unix Makefiles'),
+    Toolchain('android-ndk-r10e-api-16-armeabi-v7a-neon-clang-35', 'Unix Makefiles'),
     Toolchain('android-ndk-r10e-api-21-armeabi-v7a', 'Unix Makefiles'),
+    Toolchain('android-ndk-r10e-api-21-armeabi-v7a-neon', 'Unix Makefiles'),
+    Toolchain('android-ndk-r10e-api-21-armeabi-v7a-neon-clang-35', 'Unix Makefiles'),
+    Toolchain('android-ndk-r10e-api-21-arm64-v8a', 'Unix Makefiles'),
+    Toolchain('android-ndk-r10e-api-21-arm64-v8a-gcc-49', 'Unix Makefiles'),
+    Toolchain('android-ndk-r10e-api-21-arm64-v8a-clang-35', 'Unix Makefiles'),
     Toolchain('android-ndk-r10e-api-21-x86', 'Unix Makefiles'),
-    Toolchain('android-ndk-r10e-api-8-armeabi-v7a', 'Unix Makefiles'),
+    Toolchain('android-ndk-r10e-api-8-armeabi-v7a', 'Unix Makefiles')
 ]
 
 if os.name == 'nt':


### PR DESCRIPTION
Existing polly toolchains have not specified ANDROID_TOOLCHAIN_NAME in the filename, which implies the default of arm-linux-androideabi-4.9 in the android.toolchain.cmake file.  These will always be tied to the default, which is probably convenient for many scenarios.

I've added a few new toolchains here that explicitly specify the compiler/toolchain.  In some cases this is identical to the current default, but it will guarantee the same build type for any future releases of android.toolchain.cmake.

I suppose some versions may also want to specify ANDROID_STL as libc++ becomes more widely supported.