### PR TITLE
new toolchains + fixes 

### DIFF
--- a/android-ndk-r10e-api-16-armeabi-v7a-neon-clang-35.cmake
+++ b/android-ndk-r10e-api-16-armeabi-v7a-neon-clang-35.cmake
@@ -15,7 +15,7 @@ include("${CMAKE_CURRENT_LIST_DIR}/utilities/polly_init.cmake")
 set(ANDROID_NDK_VERSION "r10e")
 set(ANDROID_NATIVE_API_LEVEL "16")
 set(ANDROID_ABI "armeabi-v7a with NEON")
-set(ANDROIR_TOOLCHAIN_NAME "arm-linux-androideabi-clang3.5")
+set(ANDROID_TOOLCHAIN_NAME "arm-linux-androideabi-clang3.5")
 
 polly_init(
     "Android NDK ${ANDROID_NDK_VERSION} / \

--- a/bin/detail/toolchain_table.py
+++ b/bin/detail/toolchain_table.py
@@ -111,7 +111,9 @@ if platform.system() == 'Linux':
 
 if platform.system() == 'Darwin':
   toolchain_table += [
+      Toolchain('ios-8-4-libcxx', 'Xcode', ios_version='8.4'),
       Toolchain('ios-8-2', 'Xcode', ios_version='8.2'),
+      Toolchain('ios-8-2-libcxx', 'Xcode', ios_version='8.2'),
       Toolchain('ios-8-2-i386-arm64', 'Xcode', ios_version='8.2'),
       Toolchain('ios-8-2-arm64', 'Xcode', ios_version='8.2'),
       Toolchain('ios-8-2-arm64-hid', 'Xcode', ios_version='8.2'),

--- a/ios-8-2-libcxx.cmake
+++ b/ios-8-2-libcxx.cmake
@@ -1,0 +1,38 @@
+# Copyright (c) 2015, Ruslan Baratov
+# All rights reserved.
+
+if(DEFINED POLLY_IOS_8_2_LIBCXX_CMAKE_)
+  return()
+else()
+  set(POLLY_IOS_8_2_LIBCXX_CMAKE_ 1)
+endif()
+
+include("${CMAKE_CURRENT_LIST_DIR}/utilities/polly_clear_environment_variables.cmake")
+
+include("${CMAKE_CURRENT_LIST_DIR}/utilities/polly_init.cmake")
+
+set(IOS_SDK_VERSION 8.2)
+set(POLLY_XCODE_COMPILER "clang")
+polly_init(
+    "iOS ${IOS_SDK_VERSION} Universal (iphoneos + iphonesimulator) / \
+${POLLY_XCODE_COMPILER} / LLVM Standard C++ Library (libc++)  \
+c++11 support"
+    "Xcode"
+)
+
+include("${CMAKE_CURRENT_LIST_DIR}/utilities/polly_common.cmake")
+
+include(polly_fatal_error)
+
+# Fix try_compile
+set(MACOSX_BUNDLE_GUI_IDENTIFIER com.example)
+set(CMAKE_MACOSX_BUNDLE YES)
+set(CMAKE_XCODE_ATTRIBUTE_CODE_SIGN_IDENTITY "iPhone Developer")
+
+set(IPHONEOS_ARCHS armv7;armv7s;arm64)
+set(IPHONESIMULATOR_ARCHS i386;x86_64)
+
+include("${CMAKE_CURRENT_LIST_DIR}/compiler/xcode.cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/os/iphone.cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/library/std/libcxx.cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/flags/cxx11.cmake")

--- a/ios-8-4-libcxx.cmake
+++ b/ios-8-4-libcxx.cmake
@@ -1,0 +1,38 @@
+# Copyright (c) 2015, Ruslan Baratov
+# All rights reserved.
+
+if(DEFINED POLLY_IOS_8_4_LIBCXX_CMAKE_)
+  return()
+else()
+  set(POLLY_IOS_8_4_LIBCXX_CMAKE_ 1)
+endif()
+
+include("${CMAKE_CURRENT_LIST_DIR}/utilities/polly_clear_environment_variables.cmake")
+
+include("${CMAKE_CURRENT_LIST_DIR}/utilities/polly_init.cmake")
+
+set(IOS_SDK_VERSION 8.4)
+set(POLLY_XCODE_COMPILER "clang")
+polly_init(
+    "iOS ${IOS_SDK_VERSION} Universal (iphoneos + iphonesimulator) / \
+${POLLY_XCODE_COMPILER} / LLVM Standard C++ Library (libc++)  \
+c++11 support"
+    "Xcode"
+)
+
+include("${CMAKE_CURRENT_LIST_DIR}/utilities/polly_common.cmake")
+
+include(polly_fatal_error)
+
+# Fix try_compile
+set(MACOSX_BUNDLE_GUI_IDENTIFIER com.example)
+set(CMAKE_MACOSX_BUNDLE YES)
+set(CMAKE_XCODE_ATTRIBUTE_CODE_SIGN_IDENTITY "iPhone Developer")
+
+set(IPHONEOS_ARCHS armv7;armv7s;arm64)
+set(IPHONESIMULATOR_ARCHS i386;x86_64)
+
+include("${CMAKE_CURRENT_LIST_DIR}/compiler/xcode.cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/os/iphone.cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/library/std/libcxx.cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/flags/cxx11.cmake")

--- a/scripts/Info.plist
+++ b/scripts/Info.plist
@@ -9,7 +9,7 @@
     <key>CFBundleInfoDictionaryVersion</key>
     <string>6.0</string>
     <key>CFBundlePackageType</key>
-    <string>dSYM</string>
+    <string>FMWK</string>
     <key>CFBundleSignature</key>
     <string>????</string>
     <key>CFBundleShortVersionString</key>


### PR DESCRIPTION
* added 8.2 and 8.4 iOS SDK toolchains w/ libc++
* fix typo in ANDROID_TOOLCHAIN_NAME for arm-linux-androidabi-clang3.5 toolchain
* change dSYM to FMWK in dynamic framework info.plist template (see Core Foundation Keys CFBundlePackageType in https://developer.apple.com/library/ios/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html)