### PR TITLE
Add an option to generate xml output from ctest

### DIFF
--- a/bin/build.py
+++ b/bin/build.py
@@ -60,6 +60,8 @@ parser.add_argument(
 )
 
 parser.add_argument('--test', action='store_true', help="Run ctest after build")
+parser.add_argument('--test_xml', help="Save ctest output to xml")
+
 parser.add_argument('--pack', action='store_true', help="Run cpack after build")
 parser.add_argument(
     '--nobuild', action='store_true', help="Do not build (only generate)"

--- a/bin/build.py
+++ b/bin/build.py
@@ -60,7 +60,7 @@ parser.add_argument(
 )
 
 parser.add_argument('--test', action='store_true', help="Run ctest after build")
-parser.add_argument('--test_xml', help="Save ctest output to xml")
+parser.add_argument('--test-xml', help="Save ctest output to xml")
 
 parser.add_argument('--pack', action='store_true', help="Run cpack after build")
 parser.add_argument(
@@ -302,7 +302,7 @@ if not args.nobuild:
 
 if not args.nobuild:
   os.chdir(build_dir)
-  if args.test:
+  if args.test or args.test_xml:
     timer.start('Test')
     detail.test_command.run(build_dir, args.config, logging, args.test_xml)
     timer.stop()

--- a/bin/build.py
+++ b/bin/build.py
@@ -304,7 +304,7 @@ if not args.nobuild:
   os.chdir(build_dir)
   if args.test:
     timer.start('Test')
-    detail.test_command.run(build_dir, args.config, logging)
+    detail.test_command.run(build_dir, args.config, logging, args.test_xml)
     timer.stop()
   if args.pack:
     timer.start('Pack')

--- a/bin/detail/test_command.py
+++ b/bin/detail/test_command.py
@@ -5,6 +5,9 @@ import detail.call
 
 def run(build_dir, config, logging):
   test_command = ['ctest']
+  if test_xml:
+    test_command.append('-T')
+    test_command.append(test_xml)
   if config:
     test_command.append('-C')
     test_command.append(config)

--- a/bin/detail/test_command.py
+++ b/bin/detail/test_command.py
@@ -3,7 +3,7 @@
 
 import detail.call
 
-def run(build_dir, config, logging):
+def run(build_dir, config, logging,test_xml):
   test_command = ['ctest']
   if test_xml:
     test_command.append('-T')


### PR DESCRIPTION
This adds an extra option to build.py that saves the ctest output to an xml file that can be passed by the xunit plugin in jenkins.