### PR TITLE
targets mips/mips64 - api lvl 21 - ndk r10e

### DIFF
--- a/android-ndk-r10e-api-21-mips.cmake
+++ b/android-ndk-r10e-api-21-mips.cmake
@@ -1,0 +1,30 @@
+# Copyright (c) 2015, Ruslan Baratov
+# Copyright (c) 2015, Michele Caini
+# All rights reserved.
+
+if(DEFINED POLLY_ANDROID_NDK_R10E_API_21_ARMEABI_CMAKE_)
+  return()
+else()
+  set(POLLY_ANDROID_NDK_R10E_API_21_ARMEABI_CMAKE_ 1)
+endif()
+
+include("${CMAKE_CURRENT_LIST_DIR}/utilities/polly_clear_environment_variables.cmake")
+
+include("${CMAKE_CURRENT_LIST_DIR}/utilities/polly_init.cmake")
+
+set(ANDROID_NDK_VERSION "r10e")
+set(ANDROID_NATIVE_API_LEVEL "21")
+set(ANDROID_ABI "mips")
+
+polly_init(
+    "Android NDK ${ANDROID_NDK_VERSION} / \
+API ${ANDROID_NATIVE_API_LEVEL} / ${ANDROID_ABI} / \
+c++11 support"
+    "Unix Makefiles"
+)
+
+include("${CMAKE_CURRENT_LIST_DIR}/utilities/polly_common.cmake")
+
+include("${CMAKE_CURRENT_LIST_DIR}/flags/cxx11.cmake") # before toolchain!
+
+include("${CMAKE_CURRENT_LIST_DIR}/os/android.cmake")

--- a/android-ndk-r10e-api-21-mips64.cmake
+++ b/android-ndk-r10e-api-21-mips64.cmake
@@ -1,0 +1,30 @@
+# Copyright (c) 2015, Ruslan Baratov
+# Copyright (c) 2015, Michele Caini
+# All rights reserved.
+
+if(DEFINED POLLY_ANDROID_NDK_R10E_API_21_ARMEABI_CMAKE_)
+  return()
+else()
+  set(POLLY_ANDROID_NDK_R10E_API_21_ARMEABI_CMAKE_ 1)
+endif()
+
+include("${CMAKE_CURRENT_LIST_DIR}/utilities/polly_clear_environment_variables.cmake")
+
+include("${CMAKE_CURRENT_LIST_DIR}/utilities/polly_init.cmake")
+
+set(ANDROID_NDK_VERSION "r10e")
+set(ANDROID_NATIVE_API_LEVEL "21")
+set(ANDROID_ABI "mips64")
+
+polly_init(
+    "Android NDK ${ANDROID_NDK_VERSION} / \
+API ${ANDROID_NATIVE_API_LEVEL} / ${ANDROID_ABI} / \
+c++11 support"
+    "Unix Makefiles"
+)
+
+include("${CMAKE_CURRENT_LIST_DIR}/utilities/polly_common.cmake")
+
+include("${CMAKE_CURRENT_LIST_DIR}/flags/cxx11.cmake") # before toolchain!
+
+include("${CMAKE_CURRENT_LIST_DIR}/os/android.cmake")

--- a/bin/detail/toolchain_table.py
+++ b/bin/detail/toolchain_table.py
@@ -1,4 +1,5 @@
 # Copyright (c) 2014, Ruslan Baratov & Luca Martini
+# Copyright (c) 2014, Michele Caini
 # All rights reserved.
 
 import os
@@ -65,6 +66,8 @@ toolchain_table = [
     Toolchain('android-ndk-r10e-api-21-x86', 'Unix Makefiles'),
     Toolchain('android-ndk-r10e-api-21-x86-64', 'Unix Makefiles'),
     Toolchain('android-ndk-r10e-api-21-x86-64-hid', 'Unix Makefiles'),
+    Toolchain('android-ndk-r10e-api-21-mips', 'Unix Makefiles'),
+    Toolchain('android-ndk-r10e-api-21-mips64', 'Unix Makefiles'),
     Toolchain('raspberrypi2-cxx11', 'Unix Makefiles')
 ]
 


### PR DESCRIPTION
As in the title, added support for targets mips/mips64, api level 21, ndk r10e.