### PR TITLE
Implemented verbosity levels

### DIFF
--- a/bin/detail/call.py
+++ b/bin/detail/call.py
@@ -46,7 +46,7 @@ def teed_call(cmd_args, logging):
   )
   threads = []
 
-  if logging.verbose:
+  if logging.verbosity != 'silent':
     threads.append(tee(p.stdout, logging.discard, logging.log_file, sys.stdout))
     threads.append(tee(p.stderr, logging.discard, logging.log_file, sys.stderr))
   else:
@@ -63,7 +63,8 @@ def call(call_args, logging, cache_file='', ignore=False, sleep=0):
   for i in call_args:
     pretty += '  `{}`\n'.format(i)
   pretty += ']\n'
-  print(pretty)
+  if logging.verbosity == 'full':
+    print(pretty)
   logging.log_file.write(pretty)
 
   # print one line version
@@ -71,7 +72,7 @@ def call(call_args, logging, cache_file='', ignore=False, sleep=0):
   for i in call_args:
     oneline += ' "{}"'.format(i)
   oneline = "[{}]>{}\n".format(os.getcwd(), oneline)
-  if logging.verbose:
+  if logging.verbosity == 'full':
     print(oneline)
   logging.log_file.write(oneline)
 

--- a/bin/detail/call.py
+++ b/bin/detail/call.py
@@ -63,8 +63,7 @@ def call(call_args, logging, cache_file='', ignore=False, sleep=0):
   for i in call_args:
     pretty += '  `{}`\n'.format(i)
   pretty += ']\n'
-  if logging.verbosity == 'full':
-    print(pretty)
+  print(pretty)
   logging.log_file.write(pretty)
 
   # print one line version
@@ -72,7 +71,7 @@ def call(call_args, logging, cache_file='', ignore=False, sleep=0):
   for i in call_args:
     oneline += ' "{}"'.format(i)
   oneline = "[{}]>{}\n".format(os.getcwd(), oneline)
-  if logging.verbosity == 'full':
+  if logging.verbosity != 'silent':
     print(oneline)
   logging.log_file.write(oneline)
 

--- a/bin/detail/logging.py
+++ b/bin/detail/logging.py
@@ -5,8 +5,8 @@ import os
 import sys
 
 class Logging:
-  def __init__(self, cdir, verbose, discard, tail_N):
-    self.verbose = verbose
+  def __init__(self, cdir, verbosity, discard, tail_N):
+    self.verbosity = verbosity
     self.discard = discard
     self.tail_N = tail_N
 

--- a/bin/polly.py
+++ b/bin/polly.py
@@ -83,7 +83,14 @@ parser.add_argument(
 parser.add_argument(
     '--open', action='store_true', help="Open generated project (for IDE)"
 )
-parser.add_argument('--verbose', action='store_true', help="Verbose output")
+
+verbosity_group=parser.add_mutually_exclusive_group()
+verbosity_group.add_argument(
+    '--verbosity-level', dest='verbosity', help="Verbosity level",
+    choices=['silent', 'normal', 'full'], default='normal'
+)
+verbosity_group.add_argument('--verbose', action='store_true', help="Full verbose output")
+
 parser.add_argument(
     '--install', action='store_true', help="Run install (local directory)"
 )
@@ -255,10 +262,14 @@ if args.clear:
   detail.rmtree.rmtree(install_dir)
   detail.rmtree.rmtree(framework_dir)
 
+# --verbose flag triggers full verbosity level
+if args.verbose:
+    args.verbosity='full'
+
 polly_temp_dir = os.path.join(build_dir, '_3rdParty', 'polly')
 if not os.path.exists(polly_temp_dir):
   os.makedirs(polly_temp_dir)
-logging = detail.logging.Logging(cdir, args.verbose, args.discard, args.tail)
+logging = detail.logging.Logging(cdir, args.verbosity, args.discard, args.tail)
 
 if os.name == 'nt':
   # Windows
@@ -290,7 +301,8 @@ if toolchain_entry.xp:
 if toolchain_option:
   generate_command.append(toolchain_option)
 
-generate_command.append('-DCMAKE_VERBOSE_MAKEFILE=ON')
+if args.verbosity == 'full':
+    generate_command.append('-DCMAKE_VERBOSE_MAKEFILE=ON')
 generate_command.append('-DPOLLY_STATUS_DEBUG=ON')
 generate_command.append('-DHUNTER_STATUS_DEBUG=ON')
 


### PR DESCRIPTION
#81 Implementation

There are three verbosity levels now:
- silent - only basic information is shown (e.g. python version, build
  duration, logs path)
- **normal** in addition to the silent level CMake output is also sown
- full - verbose output from Makefile builds is also shown

The levels above are controlled with the `--verbosity-level` flag,
the `--verbose` flag is mutually exclusive with it and sets the
verbosity level to `full`