### PR TITLE
Debug verbosity for Polly and Hunter only shown on full in polly.py

### DIFF
--- a/bin/polly.py
+++ b/bin/polly.py
@@ -309,8 +309,8 @@ if toolchain_option:
 
 if args.verbosity == 'full':
     generate_command.append('-DCMAKE_VERBOSE_MAKEFILE=ON')
-generate_command.append('-DPOLLY_STATUS_DEBUG=ON')
-generate_command.append('-DHUNTER_STATUS_DEBUG=ON')
+    generate_command.append('-DPOLLY_STATUS_DEBUG=ON')
+    generate_command.append('-DHUNTER_STATUS_DEBUG=ON')
 
 if args.ios_multiarch:
     generate_command.append('-DCMAKE_XCODE_ATTRIBUTE_ONLY_ACTIVE_ARCH=NO')


### PR DESCRIPTION
Polly.py sets verbosity levels for Polly and Hunter to Debug all the time. This change reverts that

Looks like a mistaken indent removal 