### PR TITLE
Add ARM targets for VS 2012, 2013, 2015 and Win64 for VS 2012.

### DIFF
--- a/vs-11-2012-arm.cmake
+++ b/vs-11-2012-arm.cmake
@@ -1,0 +1,17 @@
+# Copyright (c) 2015, Ruslan Baratov
+# All rights reserved.
+
+if(DEFINED POLLY_VS_11_2012_ARM_CMAKE_)
+  return()
+else()
+  set(POLLY_VS_11_2012_ARM_CMAKE_ 1)
+endif()
+
+include("${CMAKE_CURRENT_LIST_DIR}/utilities/polly_init.cmake")
+
+polly_init(
+    "Visual Studio 11 2012 ARM"
+    "Visual Studio 11 2012 ARM"
+)
+
+include("${CMAKE_CURRENT_LIST_DIR}/utilities/polly_common.cmake")

--- a/vs-11-2012-win64.cmake
+++ b/vs-11-2012-win64.cmake
@@ -1,0 +1,17 @@
+# Copyright (c) 2015, Ruslan Baratov
+# All rights reserved.
+
+if(DEFINED POLLY_VS_11_2012_WIN64_CMAKE_)
+  return()
+else()
+  set(POLLY_VS_11_2012_WIN64_CMAKE_ 1)
+endif()
+
+include("${CMAKE_CURRENT_LIST_DIR}/utilities/polly_init.cmake")
+
+polly_init(
+    "Visual Studio 11 2012 Win64"
+    "Visual Studio 11 2012 Win64"
+)
+
+include("${CMAKE_CURRENT_LIST_DIR}/utilities/polly_common.cmake")

--- a/vs-12-2013-arm.cmake
+++ b/vs-12-2013-arm.cmake
@@ -1,0 +1,17 @@
+# Copyright (c) 2014, Ruslan Baratov
+# All rights reserved.
+
+if(DEFINED POLLY_VS_12_2013_ARM_CMAKE_)
+  return()
+else()
+  set(POLLY_VS_12_2013_ARM_CMAKE_ 1)
+endif()
+
+include("${CMAKE_CURRENT_LIST_DIR}/utilities/polly_init.cmake")
+
+polly_init(
+    "Visual Studio 12 2013 ARM"
+    "Visual Studio 12 2013 ARM"
+)
+
+include("${CMAKE_CURRENT_LIST_DIR}/utilities/polly_common.cmake")

--- a/vs-14-2015-arm.cmake
+++ b/vs-14-2015-arm.cmake
@@ -1,0 +1,17 @@
+# Copyright (c) 2016
+# All rights reserved.
+
+if(DEFINED POLLY_VS_14_2015_ARM_CMAKE_)
+  return()
+else()
+  set(POLLY_VS_14_2015_ARM_CMAKE_ 1)
+endif()
+
+include("${CMAKE_CURRENT_LIST_DIR}/utilities/polly_init.cmake")
+
+polly_init(
+    "Visual Studio 14 2015 ARM"
+    "Visual Studio 14 2015 ARM"
+)
+
+include("${CMAKE_CURRENT_LIST_DIR}/utilities/polly_common.cmake")


### PR DESCRIPTION
I hope the branch setup is okay.

I was missing the ARM targets for VS for UWP and Windows Store Apps. I noticed CMake also supported Win64 for VS 2012 which was missing too.