### PR TITLE
Added emscripten Toolchain

### DIFF
--- a/bin/detail/toolchain_table.py
+++ b/bin/detail/toolchain_table.py
@@ -91,6 +91,7 @@ toolchain_table = [
     Toolchain('android-ndk-r11c-api-21-x86-64-hid', 'Unix Makefiles'),
     Toolchain('android-ndk-r11c-api-21-mips', 'Unix Makefiles'),
     Toolchain('android-ndk-r11c-api-21-mips64', 'Unix Makefiles'),
+    Toolchain('emscripten-cxx11', 'Unix Makefiles'),
     Toolchain('raspberrypi2-cxx11', 'Unix Makefiles')
 ]
 

--- a/compiler/emscripten.cmake
+++ b/compiler/emscripten.cmake
@@ -1,0 +1,21 @@
+# Copyright (c) 2016, Alexandre Pretyman
+# All rights reserved.
+
+if(DEFINED POLLY_COMPILER_EMSCRIPTEN_CMAKE)
+  return()
+else()
+  set(POLLY_COMPILER_EMSCRIPTEN_CMAKE 1)
+endif()
+
+include(polly_fatal_error)
+
+string(COMPARE EQUAL "$ENV{EMSCRIPTEN}" "" _is_empty)
+if(_is_empty)
+  polly_fatal_error(
+    "EMSCRIPTEN environment variable not set. Emscripten environment variables are in emsdk_env.sh"
+  )
+endif()
+
+include("$ENV{EMSCRIPTEN}/cmake/Modules/Platform/Emscripten.cmake")
+list(APPEND CMAKE_FIND_ROOT_PATH "${CMAKE_CURRENT_LIST_DIR}/emscripten")
+

--- a/compiler/emscripten/glew/glewConfig.cmake
+++ b/compiler/emscripten/glew/glewConfig.cmake
@@ -1,0 +1,11 @@
+# Copyright (c) 2016, Alexandre Pretyman, Ruslan Baratov
+# Emscripten CMake target to emulate native glew::glew target
+if(NOT TARGET glew::glew)
+  add_library(glew::glew INTERFACE IMPORTED)
+  set_target_properties(
+      glew::glew
+      PROPERTIES
+        INTERFACE_COMPILE_DEFINITIONS "GLEWMX"
+        INTERFACE_LINK_LIBRARIES "-s LEGACY_GL_EMULATION=1"
+  )
+endif()

--- a/compiler/emscripten/glfw3/glfw3Config.cmake
+++ b/compiler/emscripten/glfw3/glfw3Config.cmake
@@ -1,0 +1,10 @@
+# Copyright (c) 2016, Alexandre Pretyman
+# Emscripten CMake target to emulate native glfw target
+if(NOT TARGET glfw)
+  add_library(glfw INTERFACE IMPORTED)
+  set_target_properties(
+      glfw
+      PROPERTIES
+        INTERFACE_LINK_LIBRARIES "-s LEGACY_GL_EMULATION=1;-s USE_GLFW=3"
+  )
+endif()

--- a/emscripten-cxx11.cmake
+++ b/emscripten-cxx11.cmake
@@ -1,0 +1,21 @@
+# Copyright (c) 2016, Alexandre Pretyman
+# All rights reserved.
+
+if(DEFINED POLLY_EMSCRIPTEN_CXX11_CMAKE)
+  return()
+else()
+  set(POLLY_EMSCRIPTEN_CXX11_CMAKE 1)
+endif()
+
+include("${CMAKE_CURRENT_LIST_DIR}/utilities/polly_init.cmake")
+
+polly_init(
+    "Emscripten Cross Compile / C++11"
+    "Unix Makefiles"
+)
+
+include("${CMAKE_CURRENT_LIST_DIR}/utilities/polly_common.cmake")
+include(polly_clear_environment_variables)
+include("${CMAKE_CURRENT_LIST_DIR}/flags/cxx11.cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/compiler/emscripten.cmake")
+


### PR DESCRIPTION
Reopened the pull request from: https://github.com/ruslo/polly/pull/93

I'm not sure I understood your comments here: https://github.com/ruslo/polly/pull/93#discussion_r73873153 - isn't this script loaded by polly? I didn't really understand what you meant by " pollute your current space", if you were referring to the test to `$ENV{EMSCRIPTEN}`, I prefer to have in CMake and not in polly.py because of IDE integration

It works with original CMake without needed to be patched [ emscripten doesn't really suffer from: https://cmake.org/Bug/view.php?id=15826 as these are not compilation flags as described in the issue, but linker flags, however it seems to be a real bug elsewhere: https://gitlab.kitware.com/cmake/cmake/issues/15826 ]

Added package emulation into compiler/emscripten [ I guess in this case it is tied to the toolchain, so I would think it made sense to have these in polly ]

