### PR TITLE
Cache environment variables so that regenerated builds use the same value

### DIFF
--- a/os/android.cmake
+++ b/os/android.cmake
@@ -14,15 +14,18 @@ if(_is_empty)
   polly_fatal_error("ANDROID_NDK_VERSION is not defined")
 endif()
 
-set(_env_ndk "$ENV{ANDROID_NDK_${ANDROID_NDK_VERSION}}")
-string(COMPARE EQUAL "${_env_ndk}" "" _is_empty)
+
+if(DEFINED ENV{ANDROID_NDK_${ANDROID_NDK_VERSION}})
+    set(POLLY_ANDROID_NDK "$ENV{ANDROID_NDK_${ANDROID_NDK_VERSION}}" CACHE PATH "" FORCE)
+endif()
+string(COMPARE EQUAL "${POLLY_ANDROID_NDK}" "" _is_empty)
 if(_is_empty)
   polly_fatal_error(
       "Environment variable 'ANDROID_NDK_${ANDROID_NDK_VERSION}' not set"
   )
 endif()
 
-set(ANDROID_NDK "${_env_ndk}")
+set(ANDROID_NDK "${POLLY_ANDROID_NDK}")
 
 string(COMPARE EQUAL "${CMAKE_SYSTEM_VERSION}" "" _is_empty)
 if(_is_empty)

--- a/utilities/polly_ios_development_team.cmake
+++ b/utilities/polly_ios_development_team.cmake
@@ -10,7 +10,11 @@ endif()
 include("${CMAKE_CURRENT_LIST_DIR}/polly_fatal_error.cmake")
 include("${CMAKE_CURRENT_LIST_DIR}/polly_status_debug.cmake")
 
-string(COMPARE EQUAL "$ENV{POLLY_IOS_DEVELOPMENT_TEAM}" "" _is_empty)
+
+if(DEFINED ENV{POLLY_IOS_DEVELOPMENT_TEAM})
+    set(POLLY_IOS_DEVELOPMENT_TEAM "$ENV{POLLY_IOS_DEVELOPMENT_TEAM}" CACHE STRING "" FORCE)
+endif()
+string(COMPARE EQUAL "${POLLY_IOS_DEVELOPMENT_TEAM}" "" _is_empty)
 if(_is_empty)
   polly_fatal_error(
       "Environment variable POLLY_IOS_DEVELOPMENT_TEAM is empty"
@@ -20,7 +24,7 @@ endif()
 
 set(
     CMAKE_XCODE_ATTRIBUTE_DEVELOPMENT_TEAM
-    "$ENV{POLLY_IOS_DEVELOPMENT_TEAM}"
+    "${POLLY_IOS_DEVELOPMENT_TEAM}"
 )
 
 polly_status_debug(


### PR DESCRIPTION
I normally don't keep these variables defined for my environment.  This makes working with the generated builds a bit of a pain since modifying a cmake file will cause the build to fail when it goes to regenerate.  By caching the environment variable it will simply reuse that value.