### PR TITLE
Teach polly.py about different cpack and ctest binaries

### DIFF
--- a/bin/detail/pack_command.py
+++ b/bin/detail/pack_command.py
@@ -6,15 +6,15 @@ import subprocess
 
 import detail.call
 
-def run(config, logging, cpack_generator):
-  pack_command = ['cpack']
+def run(config, logging, cpack_generator, cpack_bin, cmake_bin):
+  pack_command = [cpack_bin]
   if os.name == 'nt':
     # use full path to cpack since Chocolatey pack command has the same name
     cmake_list = subprocess.check_output(
-        ['where', 'cmake'], universal_newlines=True
+        ['where', cmake_bin], universal_newlines=True
     )
     cmake_path = cmake_list.split('\n')[0]
-    cpack_path = os.path.join(os.path.dirname(cmake_path), 'cpack')
+    cpack_path = os.path.join(os.path.dirname(cmake_path), cpack_bin)
     pack_command = [cpack_path]
   if config:
     pack_command.append('-C')

--- a/bin/detail/test_command.py
+++ b/bin/detail/test_command.py
@@ -3,8 +3,8 @@
 
 import detail.call
 
-def run(build_dir, config, logging, test_xml, verbose, timeout):
-  test_command = ['ctest']
+def run(build_dir, config, logging, test_xml, verbose, timeout, ctest_bin):
+  test_command = [ctest_bin]
   if test_xml:
     test_command.append('-T')
     test_command.append(test_xml)

--- a/bin/polly.py
+++ b/bin/polly.py
@@ -201,6 +201,16 @@ parser.add_argument(
     help="CMake binary (cmake or cmake3)"
 )
 
+parser.add_argument(
+    '--cpack',
+    help="CPack binary (cpack or cpack3)"
+)
+
+parser.add_argument(
+    '--ctest',
+    help="CTest binary (ctest or ctest3)"
+)
+
 args = parser.parse_args()
 
 polly_toolchain = detail.toolchain_name.get(args.toolchain)
@@ -448,11 +458,31 @@ if not args.nobuild:
   os.chdir(build_dir)
   if args.test or args.test_xml:
     timer.start('Test')
-    detail.test_command.run(build_dir, args.config, logging, args.test_xml, args.verbosity == 'full', args.timeout)
+
+    if args.ctest:
+      ctest_bin = args.ctest
+    else:
+      ctest_bin = 'ctest'
+
+    if os.path.isabs(ctest_bin):
+      if not os.path.exists(ctest_bin):
+        sys.exit("Ctest binary not found: {}".format(ctest_bin))
+
+    detail.test_command.run(build_dir, args.config, logging, args.test_xml, args.verbosity == 'full', args.timeout, ctest_bin)
     timer.stop()
   if args.pack:
     timer.start('Pack')
-    detail.pack_command.run(args.config, logging, cpack_generator)
+
+    if args.cpack:
+      cpack_bin = args.cpack
+    else:
+      cpack_bin = 'cpack'
+
+    if os.path.isabs(cpack_bin):
+      if not os.path.exists(cpack_bin):
+        sys.exit("CPack binary not found: {}".format(cpack_bin))
+
+    detail.pack_command.run(args.config, logging, cpack_generator, cpack_bin, cmake_bin)
     timer.stop()
 
 if args.open:


### PR DESCRIPTION
This allows me to do...

```
./polly/bin/polly --cmake cmake3 --jobs 8 --pack TBZ2 --reconfig --cpack cpack3
```

Where previously the script expected cpack only as the binary.