### PR TITLE
add gfortran to clang compiler

### DIFF
--- a/compiler/clang.cmake
+++ b/compiler/clang.cmake
@@ -18,3 +18,4 @@ endif()
 
 set(CMAKE_C_COMPILER clang CACHE STRING "C compiler" FORCE)
 set(CMAKE_CXX_COMPILER clang++ CACHE STRING "C++ compiler" FORCE)
+set(CMAKE_Fortran_COMPILER gfortran CACHE STRING "Fortran compiler" FORCE)


### PR DESCRIPTION
quickest way I could think of to set the Fortran compiler for clang builds

should fix the `clang-libstdcxx` build over at https://github.com/ruslo/hunter/pull/898#issuecomment-317642751