### PR TITLE
add compiler/gfortran

### DIFF
--- a/clang-libstdcxx.cmake
+++ b/clang-libstdcxx.cmake
@@ -21,3 +21,5 @@ include("${CMAKE_CURRENT_LIST_DIR}/library/std/libstdcxx.cmake")
 include("${CMAKE_CURRENT_LIST_DIR}/flags/cxx11.cmake")
 
 include("${CMAKE_CURRENT_LIST_DIR}/os/osx.cmake")
+
+include("${CMAKE_CURRENT_LIST_DIR}/compiler/gfortran.cmake")

--- a/compiler/gfortran.cmake
+++ b/compiler/gfortran.cmake
@@ -1,0 +1,25 @@
+# Copyright (c) 2017, NeroBurner
+# All rights reserved.
+
+if(DEFINED POLLY_COMPILER_Fortran_CMAKE)
+  return()
+else()
+  set(POLLY_COMPILER_Fortran_CMAKE 1)
+endif()
+
+find_program(CMAKE_Fortran_COMPILER gfortran)
+
+if(NOT CMAKE_Fortran_COMPILER)
+  polly_status_print("gfortran not found")
+else()
+  set(
+      CMAKE_Fortran_COMPILER
+      "${CMAKE_Fortran_COMPILER}"
+      CACHE
+      STRING
+      "Fortran compiler"
+      FORCE
+  )
+endif()
+
+


### PR DESCRIPTION
based on PR https://github.com/ruslo/polly/pull/162

adds the compiler/gfortran file and uses it in `clang-libstdcxx`

alternative to https://github.com/ruslo/polly/pull/161