### PR TITLE
split linux-mingw-w64 (non c++11 and c++11)

### DIFF
--- a/linux-mingw-w64-cxx98.cmake
+++ b/linux-mingw-w64-cxx98.cmake
@@ -1,0 +1,27 @@
+# Copyright (c) 2017, NeroBurner
+# All rights reserved.
+
+if(DEFINED POLLY_LINUX_MINGW_W64_CXX98_)
+  return()
+else()
+  set(POLLY_LINUX_MINGW_W64_CXX98_ 1)
+endif()
+
+include("${CMAKE_CURRENT_LIST_DIR}/utilities/polly_init.cmake")
+
+polly_init(
+    "Windows / mingw-w64 / x86_64 / c++98 support / static"
+    "Unix Makefiles"
+)
+
+include("${CMAKE_CURRENT_LIST_DIR}/utilities/polly_common.cmake")
+
+# need to set system name for cross compiling from linux to windows
+set(CMAKE_SYSTEM_NAME Windows)
+set(CROSS_COMPILE_TOOLCHAIN_PREFIX "x86_64-w64-mingw32")
+
+include(
+    "${CMAKE_CURRENT_LIST_DIR}/compiler/gcc-cross-compile-simple-layout.cmake"
+)
+
+include("${CMAKE_CURRENT_LIST_DIR}/flags/static.cmake")


### PR DESCRIPTION
reason for split is `ceres-solver` package. It does not handle the `-std=c++11` flag well when cross-compiling with mingw-w64

I may have to investigate why this happens with c++11 on mingw-w64 and if it still happens in 1.13.0

```
[ 28%] Building CXX object internal/ceres/CMakeFiles/ceres.dir/gradient_problem.cc.obj
In file included from /home/gc/.hunter/_Base/0af0625/8f5d145/6f1438f/Build/ceres-solver/Source/include/ceres/internal/variadic_evaluate.h:37:0,
                 from /home/gc/.hunter/_Base/0af0625/8f5d145/6f1438f/Build/ceres-solver/Source/include/ceres/internal/numeric_diff.h:45,
                 from /home/gc/.hunter/_Base/0af0625/8f5d145/6f1438f/Build/ceres-solver/Source/include/ceres/dynamic_numeric_diff_cost_function.h:44,
                 from /home/gc/.hunter/_Base/0af0625/8f5d145/6f1438f/Build/ceres-solver/Source/include/ceres/gradient_checker.h:41,
                 from /home/gc/.hunter/_Base/0af0625/8f5d145/6f1438f/Build/ceres-solver/Source/internal/ceres/gradient_checker.cc:33:
/home/gc/.hunter/_Base/0af0625/8f5d145/6f1438f/Build/ceres-solver/Source/include/ceres/jet.h: In function 'double ceres::BesselJ0(double)':
/home/gc/.hunter/_Base/0af0625/8f5d145/6f1438f/Build/ceres-solver/Source/include/ceres/jet.h:523:14: error: 'j0' was not declared in this scope
   return j0(x);
              ^
/home/gc/.hunter/_Base/0af0625/8f5d145/6f1438f/Build/ceres-solver/Source/include/ceres/jet.h: In function 'double ceres::BesselJ1(double)':
/home/gc/.hunter/_Base/0af0625/8f5d145/6f1438f/Build/ceres-solver/Source/include/ceres/jet.h:530:14: error: 'j1' was not declared in this scope
   return j1(x);
              ^
/home/gc/.hunter/_Base/0af0625/8f5d145/6f1438f/Build/ceres-solver/Source/include/ceres/jet.h: In function 'double ceres::BesselJn(int, double)':
/home/gc/.hunter/_Base/0af0625/8f5d145/6f1438f/Build/ceres-solver/Source/include/ceres/jet.h:537:17: error: 'jn' was not declared in this scope
   return jn(n, x);
                 ^
```