### PR TITLE
Linux mingw wine64

### DIFF
--- a/linux-mingw-w64-cxx98.cmake
+++ b/linux-mingw-w64-cxx98.cmake
@@ -1,0 +1,27 @@
+# Copyright (c) 2017, NeroBurner
+# All rights reserved.
+
+if(DEFINED POLLY_LINUX_MINGW_W64_CXX98_)
+  return()
+else()
+  set(POLLY_LINUX_MINGW_W64_CXX98_ 1)
+endif()
+
+include("${CMAKE_CURRENT_LIST_DIR}/utilities/polly_init.cmake")
+
+polly_init(
+    "Windows / mingw-w64 / x86_64 / c++98 support / static"
+    "Unix Makefiles"
+)
+
+include("${CMAKE_CURRENT_LIST_DIR}/utilities/polly_common.cmake")
+
+# need to set system name for cross compiling from linux to windows
+set(CMAKE_SYSTEM_NAME Windows)
+set(CROSS_COMPILE_TOOLCHAIN_PREFIX "x86_64-w64-mingw32")
+
+include(
+    "${CMAKE_CURRENT_LIST_DIR}/compiler/gcc-cross-compile-simple-layout.cmake"
+)
+
+include("${CMAKE_CURRENT_LIST_DIR}/flags/static.cmake")

--- a/linux-mingw-w64-cxx98.cmake
+++ b/linux-mingw-w64-cxx98.cmake
@@ -19,6 +19,7 @@ include("${CMAKE_CURRENT_LIST_DIR}/utilities/polly_common.cmake")
 # need to set system name for cross compiling from linux to windows
 set(CMAKE_SYSTEM_NAME Windows)
 set(CROSS_COMPILE_TOOLCHAIN_PREFIX "x86_64-w64-mingw32")
+set(CMAKE_CROSSCOMPILING_EMULATOR wine64) # used for try_run calls
 
 include(
     "${CMAKE_CURRENT_LIST_DIR}/compiler/gcc-cross-compile-simple-layout.cmake"

--- a/linux-mingw-w64.cmake
+++ b/linux-mingw-w64.cmake
@@ -19,6 +19,7 @@ include("${CMAKE_CURRENT_LIST_DIR}/utilities/polly_common.cmake")
 # need to set system name for cross compiling from linux to windows
 set(CMAKE_SYSTEM_NAME Windows)
 set(CROSS_COMPILE_TOOLCHAIN_PREFIX "x86_64-w64-mingw32")
+set(CMAKE_CROSSCOMPILING_EMULATOR wine64) # used for try_run calls
 
 include(
     "${CMAKE_CURRENT_LIST_DIR}/compiler/gcc-cross-compile-simple-layout.cmake"


### PR DESCRIPTION
add emulator wine64 to linux-mingw toolchains
this variable is used for `try_run` commands

based on https://github.com/ruslo/polly/pull/166