### PR TITLE
add toolchains for Linux armhf cross compilation

### DIFF
--- a/bin/detail/toolchain_table.py
+++ b/bin/detail/toolchain_table.py
@@ -263,6 +263,7 @@ if platform.system() == 'Linux':
       Toolchain('linux-gcc-armhf', 'Unix Makefiles'),
       Toolchain('linux-gcc-armhf-neon', 'Unix Makefiles'),
       Toolchain('linux-gcc-armhf-neon-vfpv4', 'Unix Makefiles'),
+      Toolchain('linux-gcc-jetson-tk1', 'Unix Makefiles'),
   ]
 
 if platform.system() == 'Darwin':

--- a/bin/detail/toolchain_table.py
+++ b/bin/detail/toolchain_table.py
@@ -260,6 +260,9 @@ if platform.system() == 'Linux':
       Toolchain('sanitize-thread', 'Unix Makefiles'),
       Toolchain('linux-mingw-w64', 'Unix Makefiles'),
       Toolchain('linux-mingw-w64-cxx98', 'Unix Makefiles'),
+      Toolchain('linux-gcc-armhf', 'Unix Makefiles'),
+      Toolchain('linux-gcc-armhf-neon', 'Unix Makefiles'),
+      Toolchain('linux-gcc-armhf-neon-vfpv4', 'Unix Makefiles'),
   ]
 
 if platform.system() == 'Darwin':

--- a/flags/hardfloat.cmake
+++ b/flags/hardfloat.cmake
@@ -1,0 +1,13 @@
+# Copyright (c) 2017, NeroBurner
+# All rights reserved.
+
+if(DEFINED POLLY_FLAGS_HARDFLOAT_CMAKE_)
+  return()
+else()
+  set(POLLY_FLAGS_HARDFLOAT_CMAKE_ 1)
+endif()
+
+include(polly_add_cache_flag)
+
+polly_add_cache_flag(CMAKE_CXX_FLAGS "-mfloat-abi=hard")
+polly_add_cache_flag(CMAKE_C_FLAGS "-mfloat-abi=hard")

--- a/flags/mtune_cortex-a15.cmake
+++ b/flags/mtune_cortex-a15.cmake
@@ -1,0 +1,16 @@
+# Copyright (c) 2017, NeroBurner
+# All rights reserved.
+
+if(DEFINED POLLY_FLAGS_MTUNE_CORTEX-A15_CMAKE_)
+  return()
+else()
+  set(POLLY_FLAGS_MTUNE_CORTEX-A15_CMAKE_ 1)
+endif()
+
+include(polly_add_cache_flag)
+
+# generate code that works best on the specified hardware
+list(APPEND HUNTER_TOOLCHAIN_UNDETECTABLE_ID "cortex-a15")
+polly_add_cache_flag(CMAKE_CXX_FLAGS "-mtune=cortex-a15")
+polly_add_cache_flag(CMAKE_C_FLAGS "-mtune=cortex-a15")
+

--- a/flags/neon-vfpv4.cmake
+++ b/flags/neon-vfpv4.cmake
@@ -1,0 +1,13 @@
+# Copyright (c) 2017, NeroBurner
+# All rights reserved.
+
+if(DEFINED POLLY_FLAGS_NEON_VFPV4_CMAKE_)
+  return()
+else()
+  set(POLLY_FLAGS_NEON_VFPV4_CMAKE_ 1)
+endif()
+
+include(polly_add_cache_flag)
+
+polly_add_cache_flag(CMAKE_CXX_FLAGS "-mfpu=neon-vfpv4")
+polly_add_cache_flag(CMAKE_C_FLAGS "-mfpu=neon-vfpv4")

--- a/flags/neon.cmake
+++ b/flags/neon.cmake
@@ -1,0 +1,13 @@
+# Copyright (c) 2017, NeroBurner
+# All rights reserved.
+
+if(DEFINED POLLY_FLAGS_NEON_CMAKE_)
+  return()
+else()
+  set(POLLY_FLAGS_NEON_CMAKE_ 1)
+endif()
+
+include(polly_add_cache_flag)
+
+polly_add_cache_flag(CMAKE_CXX_FLAGS "-mfpu=neon")
+polly_add_cache_flag(CMAKE_C_FLAGS "-mfpu=neon")

--- a/linux-gcc-armhf-neon-vfpv4.cmake
+++ b/linux-gcc-armhf-neon-vfpv4.cmake
@@ -1,0 +1,34 @@
+# Copyright (c) 2017, NeroBurner
+# All rights reserved.
+
+# install cross compiler on Ubuntu
+# - sudo apt install g++-arm-linux-gnueabihf
+# - with gfortran: sudo apt install gfortran-arm-linux-gnueabihf
+
+if(DEFINED POLLY_LINUX_GCC_ARMHF_NEON_VFPV4_)
+  return()
+else()
+  set(POLLY_LINUX_GCC_ARMHF_NEON_VFPV4_ 1)
+endif()
+
+include("${CMAKE_CURRENT_LIST_DIR}/utilities/polly_init.cmake")
+
+polly_init(
+    "Linux / gcc / armhf / c++11 support / neon-vfpv4"
+    "Unix Makefiles"
+)
+
+include("${CMAKE_CURRENT_LIST_DIR}/utilities/polly_common.cmake")
+
+# set system name, this sets the variable CMAKE_CROSS_COMPILING
+set(CMAKE_SYSTEM_NAME Linux)
+set(CROSS_COMPILE_TOOLCHAIN_PREFIX "arm-linux-gnueabihf")
+set(CMAKE_CROSSCOMPILING_EMULATOR qemu-arm) # used for try_run calls
+
+include(
+    "${CMAKE_CURRENT_LIST_DIR}/compiler/gcc-cross-compile-simple-layout.cmake"
+)
+include("${CMAKE_CURRENT_LIST_DIR}/flags/cxx11.cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/flags/hardfloat.cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/flags/neon-vfpv4.cmake")
+

--- a/linux-gcc-armhf-neon.cmake
+++ b/linux-gcc-armhf-neon.cmake
@@ -1,0 +1,34 @@
+# Copyright (c) 2017, NeroBurner
+# All rights reserved.
+
+# install cross compiler on Ubuntu
+# - sudo apt install g++-arm-linux-gnueabihf
+# - with gfortran: sudo apt install gfortran-arm-linux-gnueabihf
+
+if(DEFINED POLLY_LINUX_GCC_ARMHF_NEON_)
+  return()
+else()
+  set(POLLY_LINUX_GCC_ARMHF_NEON_ 1)
+endif()
+
+include("${CMAKE_CURRENT_LIST_DIR}/utilities/polly_init.cmake")
+
+polly_init(
+    "Linux / gcc / armhf / c++11 support / neon"
+    "Unix Makefiles"
+)
+
+include("${CMAKE_CURRENT_LIST_DIR}/utilities/polly_common.cmake")
+
+# set system name, this sets the variable CMAKE_CROSS_COMPILING
+set(CMAKE_SYSTEM_NAME Linux)
+set(CROSS_COMPILE_TOOLCHAIN_PREFIX "arm-linux-gnueabihf")
+set(CMAKE_CROSSCOMPILING_EMULATOR qemu-arm) # used for try_run calls
+
+include(
+    "${CMAKE_CURRENT_LIST_DIR}/compiler/gcc-cross-compile-simple-layout.cmake"
+)
+include("${CMAKE_CURRENT_LIST_DIR}/flags/cxx11.cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/flags/hardfloat.cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/flags/neon.cmake")
+

--- a/linux-gcc-armhf.cmake
+++ b/linux-gcc-armhf.cmake
@@ -1,0 +1,33 @@
+# Copyright (c) 2017, NeroBurner
+# All rights reserved.
+
+# install cross compiler on Ubuntu
+# - sudo apt install g++-arm-linux-gnueabihf
+# - with gfortran: sudo apt install gfortran-arm-linux-gnueabihf
+
+if(DEFINED POLLY_LINUX_GCC_ARMHF_)
+  return()
+else()
+  set(POLLY_LINUX_GCC_ARMHF_ 1)
+endif()
+
+include("${CMAKE_CURRENT_LIST_DIR}/utilities/polly_init.cmake")
+
+polly_init(
+    "Linux / gcc / armhf / c++11 support"
+    "Unix Makefiles"
+)
+
+include("${CMAKE_CURRENT_LIST_DIR}/utilities/polly_common.cmake")
+
+# set system name, this sets the variable CMAKE_CROSS_COMPILING
+set(CMAKE_SYSTEM_NAME Linux)
+set(CROSS_COMPILE_TOOLCHAIN_PREFIX "arm-linux-gnueabihf")
+set(CMAKE_CROSSCOMPILING_EMULATOR qemu-arm) # used for try_run calls
+
+include(
+    "${CMAKE_CURRENT_LIST_DIR}/compiler/gcc-cross-compile-simple-layout.cmake"
+)
+include("${CMAKE_CURRENT_LIST_DIR}/flags/cxx11.cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/flags/hardfloat.cmake")
+

--- a/linux-gcc-jetson-tk1.cmake
+++ b/linux-gcc-jetson-tk1.cmake
@@ -1,0 +1,35 @@
+# Copyright (c) 2017, NeroBurner
+# All rights reserved.
+
+# install cross compiler on Ubuntu
+# - sudo apt install g++-arm-linux-gnueabihf
+# - with gfortran: sudo apt install gfortran-arm-linux-gnueabihf
+
+if(DEFINED POLLY_LINUX_GCC_JETSON_TK1_)
+  return()
+else()
+  set(POLLY_LINUX_GCC_JETSON_TK1_ 1)
+endif()
+
+include("${CMAKE_CURRENT_LIST_DIR}/utilities/polly_init.cmake")
+
+polly_init(
+    "Linux / gcc / armhf / c++11 support / neon-vfpv4 / cortex-a15"
+    "Unix Makefiles"
+)
+
+include("${CMAKE_CURRENT_LIST_DIR}/utilities/polly_common.cmake")
+
+# set system name, this sets the variable CMAKE_CROSS_COMPILING
+set(CMAKE_SYSTEM_NAME Linux)
+set(CROSS_COMPILE_TOOLCHAIN_PREFIX "arm-linux-gnueabihf")
+set(CMAKE_CROSSCOMPILING_EMULATOR qemu-arm) # used for try_run calls
+
+include(
+    "${CMAKE_CURRENT_LIST_DIR}/compiler/gcc-cross-compile-simple-layout.cmake"
+)
+include("${CMAKE_CURRENT_LIST_DIR}/flags/cxx11.cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/flags/hardfloat.cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/flags/neon-vfpv4.cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/flags/mtune_cortex-a15.cmake")
+


### PR DESCRIPTION
add cross compile toolchains
- armhf
- armhf + neon
- armhf + neon-vfpv4
- jetson-tk1 (armhf + neon-vfpv4 + cortex-a15)