### PR TITLE
Fix try-compile on iOS for Apple Enterprise accounts.

### DIFF
--- a/docs/toolchains/ios/errors/polly_ios_bundle_identifier.rst
+++ b/docs/toolchains/ios/errors/polly_ios_bundle_identifier.rst
@@ -1,0 +1,24 @@
+.. Copyright (c) 2016, Ruslan Baratov
+.. All rights reserved.
+
+POLLY_IOS_BUNDLE_IDENTIFIER
+===========================
+When using an Apple Enterprise developer account, the ``CMAKE_TRY_COMPILE`` step
+can fail with this message
+
+.. code-block:: none
+
+  No profiles for 'com.example' were found: Xcode couldn't find a
+  provisioning profile matching 'com.example'.
+
+
+You can bypass this problem by creating a project with a unique bundle
+identifier, i.e. ``com.<company-name>.example`` and setting the environment
+variable ``POLLY_IOS_BUNDLE_IDENTIFIER``. If the environment variable exists,
+Polly will set the corresponding CMake variable ``MACOSX_BUNDLE_GUI_IDENTIFIER``
+, otherwise it is set to ``com.example``.
+
+.. code-block:: none
+
+  > grep POLLY_IOS_BUNDLE_IDENTIFIER ~/.bashrc
+  export POLLY_IOS_BUNDLE_IDENTIFIER="com.<company-name>.example"

--- a/ios-10-0-arm64-dep-8-0-hid-sections.cmake
+++ b/ios-10-0-arm64-dep-8-0-hid-sections.cmake
@@ -29,7 +29,7 @@ include("${CMAKE_CURRENT_LIST_DIR}/utilities/polly_common.cmake")
 include(polly_fatal_error)
 
 # Fix try_compile
-set(MACOSX_BUNDLE_GUI_IDENTIFIER com.example)
+include(polly_ios_bundle_identifier)
 set(CMAKE_MACOSX_BUNDLE YES)
 set(CMAKE_XCODE_ATTRIBUTE_CODE_SIGN_IDENTITY "iPhone Developer")
 

--- a/ios-10-0-arm64.cmake
+++ b/ios-10-0-arm64.cmake
@@ -26,7 +26,7 @@ include("${CMAKE_CURRENT_LIST_DIR}/utilities/polly_common.cmake")
 include(polly_fatal_error)
 
 # Fix try_compile
-set(MACOSX_BUNDLE_GUI_IDENTIFIER com.example)
+include(polly_ios_bundle_identifier)
 set(CMAKE_MACOSX_BUNDLE YES)
 set(CMAKE_XCODE_ATTRIBUTE_CODE_SIGN_IDENTITY "iPhone Developer")
 

--- a/ios-10-0-armv7.cmake
+++ b/ios-10-0-armv7.cmake
@@ -26,7 +26,7 @@ include("${CMAKE_CURRENT_LIST_DIR}/utilities/polly_common.cmake")
 include(polly_fatal_error)
 
 # Fix try_compile
-set(MACOSX_BUNDLE_GUI_IDENTIFIER com.example)
+include(polly_ios_bundle_identifier)
 set(CMAKE_MACOSX_BUNDLE YES)
 set(CMAKE_XCODE_ATTRIBUTE_CODE_SIGN_IDENTITY "iPhone Developer")
 

--- a/ios-10-0-dep-8-0-hid-sections.cmake
+++ b/ios-10-0-dep-8-0-hid-sections.cmake
@@ -29,7 +29,7 @@ include("${CMAKE_CURRENT_LIST_DIR}/utilities/polly_common.cmake")
 include(polly_fatal_error)
 
 # Fix try_compile
-set(MACOSX_BUNDLE_GUI_IDENTIFIER com.example)
+include(polly_ios_bundle_identifier)
 set(CMAKE_MACOSX_BUNDLE YES)
 set(CMAKE_XCODE_ATTRIBUTE_CODE_SIGN_IDENTITY "iPhone Developer")
 

--- a/ios-10-0-wo-armv7s.cmake
+++ b/ios-10-0-wo-armv7s.cmake
@@ -26,7 +26,7 @@ include("${CMAKE_CURRENT_LIST_DIR}/utilities/polly_common.cmake")
 include(polly_fatal_error)
 
 # Fix try_compile
-set(MACOSX_BUNDLE_GUI_IDENTIFIER com.example)
+include(polly_ios_bundle_identifier)
 set(CMAKE_MACOSX_BUNDLE YES)
 set(CMAKE_XCODE_ATTRIBUTE_CODE_SIGN_IDENTITY "iPhone Developer")
 

--- a/ios-10-0.cmake
+++ b/ios-10-0.cmake
@@ -25,7 +25,7 @@ include("${CMAKE_CURRENT_LIST_DIR}/utilities/polly_common.cmake")
 include(polly_fatal_error)
 
 # Fix try_compile
-set(MACOSX_BUNDLE_GUI_IDENTIFIER com.example)
+include(polly_ios_bundle_identifier)
 set(CMAKE_MACOSX_BUNDLE YES)
 set(CMAKE_XCODE_ATTRIBUTE_CODE_SIGN_IDENTITY "iPhone Developer")
 

--- a/ios-10-1-arm64-dep-8-0-hid-sections.cmake
+++ b/ios-10-1-arm64-dep-8-0-hid-sections.cmake
@@ -29,7 +29,7 @@ include("${CMAKE_CURRENT_LIST_DIR}/utilities/polly_common.cmake")
 include(polly_fatal_error)
 
 # Fix try_compile
-set(MACOSX_BUNDLE_GUI_IDENTIFIER com.example)
+include(polly_ios_bundle_identifier)
 set(CMAKE_MACOSX_BUNDLE YES)
 set(CMAKE_XCODE_ATTRIBUTE_CODE_SIGN_IDENTITY "iPhone Developer")
 

--- a/ios-10-1-arm64.cmake
+++ b/ios-10-1-arm64.cmake
@@ -26,7 +26,7 @@ include("${CMAKE_CURRENT_LIST_DIR}/utilities/polly_common.cmake")
 include(polly_fatal_error)
 
 # Fix try_compile
-set(MACOSX_BUNDLE_GUI_IDENTIFIER com.example)
+include(polly_ios_bundle_identifier)
 set(CMAKE_MACOSX_BUNDLE YES)
 set(CMAKE_XCODE_ATTRIBUTE_CODE_SIGN_IDENTITY "iPhone Developer")
 

--- a/ios-10-1-armv7.cmake
+++ b/ios-10-1-armv7.cmake
@@ -26,7 +26,7 @@ include("${CMAKE_CURRENT_LIST_DIR}/utilities/polly_common.cmake")
 include(polly_fatal_error)
 
 # Fix try_compile
-set(MACOSX_BUNDLE_GUI_IDENTIFIER com.example)
+include(polly_ios_bundle_identifier)
 set(CMAKE_MACOSX_BUNDLE YES)
 set(CMAKE_XCODE_ATTRIBUTE_CODE_SIGN_IDENTITY "iPhone Developer")
 

--- a/ios-10-1-dep-8-0-hid-sections.cmake
+++ b/ios-10-1-dep-8-0-hid-sections.cmake
@@ -29,7 +29,7 @@ include("${CMAKE_CURRENT_LIST_DIR}/utilities/polly_common.cmake")
 include(polly_fatal_error)
 
 # Fix try_compile
-set(MACOSX_BUNDLE_GUI_IDENTIFIER com.example)
+include(polly_ios_bundle_identifier)
 set(CMAKE_MACOSX_BUNDLE YES)
 set(CMAKE_XCODE_ATTRIBUTE_CODE_SIGN_IDENTITY "iPhone Developer")
 

--- a/ios-10-1-dep-8-0-libcxx-hid-sections-lto.cmake
+++ b/ios-10-1-dep-8-0-libcxx-hid-sections-lto.cmake
@@ -29,7 +29,7 @@ include("${CMAKE_CURRENT_LIST_DIR}/utilities/polly_common.cmake")
 include(polly_fatal_error)
 
 # Fix try_compile
-set(MACOSX_BUNDLE_GUI_IDENTIFIER com.example)
+include(polly_ios_bundle_identifier)
 set(CMAKE_MACOSX_BUNDLE YES)
 set(CMAKE_XCODE_ATTRIBUTE_CODE_SIGN_IDENTITY "iPhone Developer")
 

--- a/ios-10-1-dep-8-0-libcxx-hid-sections.cmake
+++ b/ios-10-1-dep-8-0-libcxx-hid-sections.cmake
@@ -29,7 +29,7 @@ include("${CMAKE_CURRENT_LIST_DIR}/utilities/polly_common.cmake")
 include(polly_fatal_error)
 
 # Fix try_compile
-set(MACOSX_BUNDLE_GUI_IDENTIFIER com.example)
+include(polly_ios_bundle_identifier)
 set(CMAKE_MACOSX_BUNDLE YES)
 set(CMAKE_XCODE_ATTRIBUTE_CODE_SIGN_IDENTITY "iPhone Developer")
 

--- a/ios-10-1-wo-armv7s.cmake
+++ b/ios-10-1-wo-armv7s.cmake
@@ -26,7 +26,7 @@ include("${CMAKE_CURRENT_LIST_DIR}/utilities/polly_common.cmake")
 include(polly_fatal_error)
 
 # Fix try_compile
-set(MACOSX_BUNDLE_GUI_IDENTIFIER com.example)
+include(polly_ios_bundle_identifier)
 set(CMAKE_MACOSX_BUNDLE YES)
 set(CMAKE_XCODE_ATTRIBUTE_CODE_SIGN_IDENTITY "iPhone Developer")
 

--- a/ios-10-1.cmake
+++ b/ios-10-1.cmake
@@ -25,7 +25,7 @@ include("${CMAKE_CURRENT_LIST_DIR}/utilities/polly_common.cmake")
 include(polly_fatal_error)
 
 # Fix try_compile
-set(MACOSX_BUNDLE_GUI_IDENTIFIER com.example)
+include(polly_ios_bundle_identifier)
 set(CMAKE_MACOSX_BUNDLE YES)
 set(CMAKE_XCODE_ATTRIBUTE_CODE_SIGN_IDENTITY "iPhone Developer")
 

--- a/ios-10-2-dep-9-3-arm64.cmake
+++ b/ios-10-2-dep-9-3-arm64.cmake
@@ -28,7 +28,7 @@ include("${CMAKE_CURRENT_LIST_DIR}/utilities/polly_common.cmake")
 include(polly_fatal_error)
 
 # Fix try_compile
-set(MACOSX_BUNDLE_GUI_IDENTIFIER com.example)
+include(polly_ios_bundle_identifier)
 set(CMAKE_MACOSX_BUNDLE YES)
 set(CMAKE_XCODE_ATTRIBUTE_CODE_SIGN_IDENTITY "iPhone Developer")
 

--- a/ios-10-2-dep-9-3-armv7.cmake
+++ b/ios-10-2-dep-9-3-armv7.cmake
@@ -28,7 +28,7 @@ include("${CMAKE_CURRENT_LIST_DIR}/utilities/polly_common.cmake")
 include(polly_fatal_error)
 
 # Fix try_compile
-set(MACOSX_BUNDLE_GUI_IDENTIFIER com.example)
+include(polly_ios_bundle_identifier)
 set(CMAKE_MACOSX_BUNDLE YES)
 set(CMAKE_XCODE_ATTRIBUTE_CODE_SIGN_IDENTITY "iPhone Developer")
 

--- a/ios-10-2.cmake
+++ b/ios-10-2.cmake
@@ -25,7 +25,7 @@ include("${CMAKE_CURRENT_LIST_DIR}/utilities/polly_common.cmake")
 include(polly_fatal_error)
 
 # Fix try_compile
-set(MACOSX_BUNDLE_GUI_IDENTIFIER com.example)
+include(polly_ios_bundle_identifier)
 set(CMAKE_MACOSX_BUNDLE YES)
 set(CMAKE_XCODE_ATTRIBUTE_CODE_SIGN_IDENTITY "iPhone Developer")
 

--- a/ios-10-3-armv7.cmake
+++ b/ios-10-3-armv7.cmake
@@ -26,7 +26,8 @@ include("${CMAKE_CURRENT_LIST_DIR}/utilities/polly_common.cmake")
 include(polly_fatal_error)
 
 # Fix try_compile
-set(MACOSX_BUNDLE_GUI_IDENTIFIER com.example)
+include(polly_ios_bundle_identifier)
+
 set(CMAKE_MACOSX_BUNDLE YES)
 set(CMAKE_XCODE_ATTRIBUTE_CODE_SIGN_IDENTITY "iPhone Developer")
 

--- a/ios-10-3-dep-8-0-bitcode.cmake
+++ b/ios-10-3-dep-8-0-bitcode.cmake
@@ -28,7 +28,8 @@ include("${CMAKE_CURRENT_LIST_DIR}/utilities/polly_common.cmake")
 include(polly_fatal_error)
 
 # Fix try_compile
-set(MACOSX_BUNDLE_GUI_IDENTIFIER com.example)
+include(polly_ios_bundle_identifier)
+
 set(CMAKE_MACOSX_BUNDLE YES)
 set(CMAKE_XCODE_ATTRIBUTE_CODE_SIGN_IDENTITY "iPhone Developer")
 

--- a/ios-10-3-dep-9-0-bitcode.cmake
+++ b/ios-10-3-dep-9-0-bitcode.cmake
@@ -28,7 +28,8 @@ include("${CMAKE_CURRENT_LIST_DIR}/utilities/polly_common.cmake")
 include(polly_fatal_error)
 
 # Fix try_compile
-set(MACOSX_BUNDLE_GUI_IDENTIFIER com.example)
+include(polly_ios_bundle_identifier)
+
 set(CMAKE_MACOSX_BUNDLE YES)
 set(CMAKE_XCODE_ATTRIBUTE_CODE_SIGN_IDENTITY "iPhone Developer")
 

--- a/ios-10-3-dep-9-3-i386-armv7.cmake
+++ b/ios-10-3-dep-9-3-i386-armv7.cmake
@@ -28,7 +28,8 @@ include("${CMAKE_CURRENT_LIST_DIR}/utilities/polly_common.cmake")
 include(polly_fatal_error)
 
 # Fix try_compile
-set(MACOSX_BUNDLE_GUI_IDENTIFIER com.example)
+include(polly_ios_bundle_identifier)
+
 set(CMAKE_MACOSX_BUNDLE YES)
 set(CMAKE_XCODE_ATTRIBUTE_CODE_SIGN_IDENTITY "iPhone Developer")
 

--- a/ios-10-3-dep-9-3-x86-64-arm64.cmake
+++ b/ios-10-3-dep-9-3-x86-64-arm64.cmake
@@ -28,7 +28,8 @@ include("${CMAKE_CURRENT_LIST_DIR}/utilities/polly_common.cmake")
 include(polly_fatal_error)
 
 # Fix try_compile
-set(MACOSX_BUNDLE_GUI_IDENTIFIER com.example)
+include(polly_ios_bundle_identifier)
+
 set(CMAKE_MACOSX_BUNDLE YES)
 set(CMAKE_XCODE_ATTRIBUTE_CODE_SIGN_IDENTITY "iPhone Developer")
 

--- a/ios-10-3-lto.cmake
+++ b/ios-10-3-lto.cmake
@@ -25,7 +25,8 @@ include("${CMAKE_CURRENT_LIST_DIR}/utilities/polly_common.cmake")
 include(polly_fatal_error)
 
 # Fix try_compile
-set(MACOSX_BUNDLE_GUI_IDENTIFIER com.example)
+include(polly_ios_bundle_identifier)
+
 set(CMAKE_MACOSX_BUNDLE YES)
 set(CMAKE_XCODE_ATTRIBUTE_CODE_SIGN_IDENTITY "iPhone Developer")
 

--- a/ios-10-3.cmake
+++ b/ios-10-3.cmake
@@ -25,7 +25,8 @@ include("${CMAKE_CURRENT_LIST_DIR}/utilities/polly_common.cmake")
 include(polly_fatal_error)
 
 # Fix try_compile
-set(MACOSX_BUNDLE_GUI_IDENTIFIER com.example)
+include(polly_ios_bundle_identifier)
+
 set(CMAKE_MACOSX_BUNDLE YES)
 set(CMAKE_XCODE_ATTRIBUTE_CODE_SIGN_IDENTITY "iPhone Developer")
 

--- a/ios-7-0.cmake
+++ b/ios-7-0.cmake
@@ -25,7 +25,7 @@ include("${CMAKE_CURRENT_LIST_DIR}/utilities/polly_common.cmake")
 include(polly_fatal_error)
 
 # Fix try_compile
-set(MACOSX_BUNDLE_GUI_IDENTIFIER com.example)
+include(polly_ios_bundle_identifier)
 set(CMAKE_MACOSX_BUNDLE YES)
 set(CMAKE_XCODE_ATTRIBUTE_CODE_SIGN_IDENTITY "iPhone Developer")
 

--- a/ios-7-1.cmake
+++ b/ios-7-1.cmake
@@ -25,7 +25,7 @@ include("${CMAKE_CURRENT_LIST_DIR}/utilities/polly_common.cmake")
 include(polly_fatal_error)
 
 # Fix try_compile
-set(MACOSX_BUNDLE_GUI_IDENTIFIER com.example)
+include(polly_ios_bundle_identifier)
 set(CMAKE_MACOSX_BUNDLE YES)
 set(CMAKE_XCODE_ATTRIBUTE_CODE_SIGN_IDENTITY "iPhone Developer")
 

--- a/ios-8-0.cmake
+++ b/ios-8-0.cmake
@@ -25,7 +25,7 @@ include("${CMAKE_CURRENT_LIST_DIR}/utilities/polly_common.cmake")
 include(polly_fatal_error)
 
 # Fix try_compile
-set(MACOSX_BUNDLE_GUI_IDENTIFIER com.example)
+include(polly_ios_bundle_identifier)
 set(CMAKE_MACOSX_BUNDLE YES)
 set(CMAKE_XCODE_ATTRIBUTE_CODE_SIGN_IDENTITY "iPhone Developer")
 

--- a/ios-8-1.cmake
+++ b/ios-8-1.cmake
@@ -25,7 +25,7 @@ include("${CMAKE_CURRENT_LIST_DIR}/utilities/polly_common.cmake")
 include(polly_fatal_error)
 
 # Fix try_compile
-set(MACOSX_BUNDLE_GUI_IDENTIFIER com.example)
+include(polly_ios_bundle_identifier)
 set(CMAKE_MACOSX_BUNDLE YES)
 set(CMAKE_XCODE_ATTRIBUTE_CODE_SIGN_IDENTITY "iPhone Developer")
 

--- a/ios-8-2-arm64-hid.cmake
+++ b/ios-8-2-arm64-hid.cmake
@@ -26,7 +26,7 @@ include("${CMAKE_CURRENT_LIST_DIR}/utilities/polly_common.cmake")
 include(polly_fatal_error)
 
 # Fix try_compile
-set(MACOSX_BUNDLE_GUI_IDENTIFIER com.example)
+include(polly_ios_bundle_identifier)
 set(CMAKE_MACOSX_BUNDLE YES)
 set(CMAKE_XCODE_ATTRIBUTE_CODE_SIGN_IDENTITY "iPhone Developer")
 

--- a/ios-8-2-arm64.cmake
+++ b/ios-8-2-arm64.cmake
@@ -26,7 +26,7 @@ include("${CMAKE_CURRENT_LIST_DIR}/utilities/polly_common.cmake")
 include(polly_fatal_error)
 
 # Fix try_compile
-set(MACOSX_BUNDLE_GUI_IDENTIFIER com.example)
+include(polly_ios_bundle_identifier)
 set(CMAKE_MACOSX_BUNDLE YES)
 set(CMAKE_XCODE_ATTRIBUTE_CODE_SIGN_IDENTITY "iPhone Developer")
 

--- a/ios-8-2-cxx98.cmake
+++ b/ios-8-2-cxx98.cmake
@@ -25,7 +25,7 @@ include("${CMAKE_CURRENT_LIST_DIR}/utilities/polly_common.cmake")
 include(polly_fatal_error)
 
 # Fix try_compile
-set(MACOSX_BUNDLE_GUI_IDENTIFIER com.example)
+include(polly_ios_bundle_identifier)
 set(CMAKE_MACOSX_BUNDLE YES)
 set(CMAKE_XCODE_ATTRIBUTE_CODE_SIGN_IDENTITY "iPhone Developer")
 

--- a/ios-8-2-i386-arm64.cmake
+++ b/ios-8-2-i386-arm64.cmake
@@ -26,7 +26,7 @@ include("${CMAKE_CURRENT_LIST_DIR}/utilities/polly_common.cmake")
 include(polly_fatal_error)
 
 # Fix try_compile
-set(MACOSX_BUNDLE_GUI_IDENTIFIER com.example)
+include(polly_ios_bundle_identifier)
 set(CMAKE_MACOSX_BUNDLE YES)
 set(CMAKE_XCODE_ATTRIBUTE_CODE_SIGN_IDENTITY "iPhone Developer")
 

--- a/ios-8-2.cmake
+++ b/ios-8-2.cmake
@@ -25,7 +25,7 @@ include("${CMAKE_CURRENT_LIST_DIR}/utilities/polly_common.cmake")
 include(polly_fatal_error)
 
 # Fix try_compile
-set(MACOSX_BUNDLE_GUI_IDENTIFIER com.example)
+include(polly_ios_bundle_identifier)
 set(CMAKE_MACOSX_BUNDLE YES)
 set(CMAKE_XCODE_ATTRIBUTE_CODE_SIGN_IDENTITY "iPhone Developer")
 

--- a/ios-8-4-arm64.cmake
+++ b/ios-8-4-arm64.cmake
@@ -26,7 +26,7 @@ include("${CMAKE_CURRENT_LIST_DIR}/utilities/polly_common.cmake")
 include(polly_fatal_error)
 
 # Fix try_compile
-set(MACOSX_BUNDLE_GUI_IDENTIFIER com.example)
+include(polly_ios_bundle_identifier)
 set(CMAKE_MACOSX_BUNDLE YES)
 set(CMAKE_XCODE_ATTRIBUTE_CODE_SIGN_IDENTITY "iPhone Developer")
 

--- a/ios-8-4-armv7.cmake
+++ b/ios-8-4-armv7.cmake
@@ -26,7 +26,7 @@ include("${CMAKE_CURRENT_LIST_DIR}/utilities/polly_common.cmake")
 include(polly_fatal_error)
 
 # Fix try_compile
-set(MACOSX_BUNDLE_GUI_IDENTIFIER com.example)
+include(polly_ios_bundle_identifier)
 set(CMAKE_MACOSX_BUNDLE YES)
 set(CMAKE_XCODE_ATTRIBUTE_CODE_SIGN_IDENTITY "iPhone Developer")
 

--- a/ios-8-4-armv7s.cmake
+++ b/ios-8-4-armv7s.cmake
@@ -26,7 +26,7 @@ include("${CMAKE_CURRENT_LIST_DIR}/utilities/polly_common.cmake")
 include(polly_fatal_error)
 
 # Fix try_compile
-set(MACOSX_BUNDLE_GUI_IDENTIFIER com.example)
+include(polly_ios_bundle_identifier)
 set(CMAKE_MACOSX_BUNDLE YES)
 set(CMAKE_XCODE_ATTRIBUTE_CODE_SIGN_IDENTITY "iPhone Developer")
 

--- a/ios-8-4-hid.cmake
+++ b/ios-8-4-hid.cmake
@@ -27,7 +27,7 @@ include("${CMAKE_CURRENT_LIST_DIR}/utilities/polly_common.cmake")
 include(polly_fatal_error)
 
 # Fix try_compile
-set(MACOSX_BUNDLE_GUI_IDENTIFIER com.example)
+include(polly_ios_bundle_identifier)
 set(CMAKE_MACOSX_BUNDLE YES)
 set(CMAKE_XCODE_ATTRIBUTE_CODE_SIGN_IDENTITY "iPhone Developer")
 

--- a/ios-8-4.cmake
+++ b/ios-8-4.cmake
@@ -25,7 +25,7 @@ include("${CMAKE_CURRENT_LIST_DIR}/utilities/polly_common.cmake")
 include(polly_fatal_error)
 
 # Fix try_compile
-set(MACOSX_BUNDLE_GUI_IDENTIFIER com.example)
+include(polly_ios_bundle_identifier)
 set(CMAKE_MACOSX_BUNDLE YES)
 set(CMAKE_XCODE_ATTRIBUTE_CODE_SIGN_IDENTITY "iPhone Developer")
 

--- a/ios-9-0-armv7.cmake
+++ b/ios-9-0-armv7.cmake
@@ -26,7 +26,7 @@ include("${CMAKE_CURRENT_LIST_DIR}/utilities/polly_common.cmake")
 include(polly_fatal_error)
 
 # Fix try_compile
-set(MACOSX_BUNDLE_GUI_IDENTIFIER com.example)
+include(polly_ios_bundle_identifier)
 set(CMAKE_MACOSX_BUNDLE YES)
 set(CMAKE_XCODE_ATTRIBUTE_CODE_SIGN_IDENTITY "iPhone Developer")
 

--- a/ios-9-0-dep-7-0-armv7.cmake
+++ b/ios-9-0-dep-7-0-armv7.cmake
@@ -28,7 +28,7 @@ include("${CMAKE_CURRENT_LIST_DIR}/utilities/polly_common.cmake")
 include(polly_fatal_error)
 
 # Fix try_compile
-set(MACOSX_BUNDLE_GUI_IDENTIFIER com.example)
+include(polly_ios_bundle_identifier)
 set(CMAKE_MACOSX_BUNDLE YES)
 set(CMAKE_XCODE_ATTRIBUTE_CODE_SIGN_IDENTITY "iPhone Developer")
 

--- a/ios-9-0-i386-armv7.cmake
+++ b/ios-9-0-i386-armv7.cmake
@@ -26,7 +26,7 @@ include("${CMAKE_CURRENT_LIST_DIR}/utilities/polly_common.cmake")
 include(polly_fatal_error)
 
 # Fix try_compile
-set(MACOSX_BUNDLE_GUI_IDENTIFIER com.example)
+include(polly_ios_bundle_identifier)
 set(CMAKE_MACOSX_BUNDLE YES)
 set(CMAKE_XCODE_ATTRIBUTE_CODE_SIGN_IDENTITY "iPhone Developer")
 

--- a/ios-9-0-wo-armv7s.cmake
+++ b/ios-9-0-wo-armv7s.cmake
@@ -26,7 +26,7 @@ include("${CMAKE_CURRENT_LIST_DIR}/utilities/polly_common.cmake")
 include(polly_fatal_error)
 
 # Fix try_compile
-set(MACOSX_BUNDLE_GUI_IDENTIFIER com.example)
+include(polly_ios_bundle_identifier)
 set(CMAKE_MACOSX_BUNDLE YES)
 set(CMAKE_XCODE_ATTRIBUTE_CODE_SIGN_IDENTITY "iPhone Developer")
 

--- a/ios-9-0.cmake
+++ b/ios-9-0.cmake
@@ -25,7 +25,7 @@ include("${CMAKE_CURRENT_LIST_DIR}/utilities/polly_common.cmake")
 include(polly_fatal_error)
 
 # Fix try_compile
-set(MACOSX_BUNDLE_GUI_IDENTIFIER com.example)
+include(polly_ios_bundle_identifier)
 set(CMAKE_MACOSX_BUNDLE YES)
 set(CMAKE_XCODE_ATTRIBUTE_CODE_SIGN_IDENTITY "iPhone Developer")
 

--- a/ios-9-1-arm64.cmake
+++ b/ios-9-1-arm64.cmake
@@ -26,7 +26,7 @@ include("${CMAKE_CURRENT_LIST_DIR}/utilities/polly_common.cmake")
 include(polly_fatal_error)
 
 # Fix try_compile
-set(MACOSX_BUNDLE_GUI_IDENTIFIER com.example)
+include(polly_ios_bundle_identifier)
 set(CMAKE_MACOSX_BUNDLE YES)
 set(CMAKE_XCODE_ATTRIBUTE_CODE_SIGN_IDENTITY "iPhone Developer")
 

--- a/ios-9-1-armv7.cmake
+++ b/ios-9-1-armv7.cmake
@@ -26,7 +26,7 @@ include("${CMAKE_CURRENT_LIST_DIR}/utilities/polly_common.cmake")
 include(polly_fatal_error)
 
 # Fix try_compile
-set(MACOSX_BUNDLE_GUI_IDENTIFIER com.example)
+include(polly_ios_bundle_identifier)
 set(CMAKE_MACOSX_BUNDLE YES)
 set(CMAKE_XCODE_ATTRIBUTE_CODE_SIGN_IDENTITY "iPhone Developer")
 

--- a/ios-9-1-dep-7-0-armv7.cmake
+++ b/ios-9-1-dep-7-0-armv7.cmake
@@ -28,7 +28,7 @@ include("${CMAKE_CURRENT_LIST_DIR}/utilities/polly_common.cmake")
 include(polly_fatal_error)
 
 # Fix try_compile
-set(MACOSX_BUNDLE_GUI_IDENTIFIER com.example)
+include(polly_ios_bundle_identifier)
 set(CMAKE_MACOSX_BUNDLE YES)
 set(CMAKE_XCODE_ATTRIBUTE_CODE_SIGN_IDENTITY "iPhone Developer")
 

--- a/ios-9-1-dep-8-0-hid.cmake
+++ b/ios-9-1-dep-8-0-hid.cmake
@@ -29,7 +29,7 @@ include("${CMAKE_CURRENT_LIST_DIR}/utilities/polly_common.cmake")
 include(polly_fatal_error)
 
 # Fix try_compile
-set(MACOSX_BUNDLE_GUI_IDENTIFIER com.example)
+include(polly_ios_bundle_identifier)
 set(CMAKE_MACOSX_BUNDLE YES)
 set(CMAKE_XCODE_ATTRIBUTE_CODE_SIGN_IDENTITY "iPhone Developer")
 

--- a/ios-9-1-hid.cmake
+++ b/ios-9-1-hid.cmake
@@ -27,7 +27,7 @@ include("${CMAKE_CURRENT_LIST_DIR}/utilities/polly_common.cmake")
 include(polly_fatal_error)
 
 # Fix try_compile
-set(MACOSX_BUNDLE_GUI_IDENTIFIER com.example)
+include(polly_ios_bundle_identifier)
 set(CMAKE_MACOSX_BUNDLE YES)
 set(CMAKE_XCODE_ATTRIBUTE_CODE_SIGN_IDENTITY "iPhone Developer")
 

--- a/ios-9-1.cmake
+++ b/ios-9-1.cmake
@@ -25,7 +25,7 @@ include("${CMAKE_CURRENT_LIST_DIR}/utilities/polly_common.cmake")
 include(polly_fatal_error)
 
 # Fix try_compile
-set(MACOSX_BUNDLE_GUI_IDENTIFIER com.example)
+include(polly_ios_bundle_identifier)
 set(CMAKE_MACOSX_BUNDLE YES)
 set(CMAKE_XCODE_ATTRIBUTE_CODE_SIGN_IDENTITY "iPhone Developer")
 

--- a/ios-9-2-arm64.cmake
+++ b/ios-9-2-arm64.cmake
@@ -26,7 +26,7 @@ include("${CMAKE_CURRENT_LIST_DIR}/utilities/polly_common.cmake")
 include(polly_fatal_error)
 
 # Fix try_compile
-set(MACOSX_BUNDLE_GUI_IDENTIFIER com.example)
+include(polly_ios_bundle_identifier)
 set(CMAKE_MACOSX_BUNDLE YES)
 set(CMAKE_XCODE_ATTRIBUTE_CODE_SIGN_IDENTITY "iPhone Developer")
 

--- a/ios-9-2-armv7.cmake
+++ b/ios-9-2-armv7.cmake
@@ -26,7 +26,7 @@ include("${CMAKE_CURRENT_LIST_DIR}/utilities/polly_common.cmake")
 include(polly_fatal_error)
 
 # Fix try_compile
-set(MACOSX_BUNDLE_GUI_IDENTIFIER com.example)
+include(polly_ios_bundle_identifier)
 set(CMAKE_MACOSX_BUNDLE YES)
 set(CMAKE_XCODE_ATTRIBUTE_CODE_SIGN_IDENTITY "iPhone Developer")
 

--- a/ios-9-2-hid-sections.cmake
+++ b/ios-9-2-hid-sections.cmake
@@ -27,7 +27,7 @@ include("${CMAKE_CURRENT_LIST_DIR}/utilities/polly_common.cmake")
 include(polly_fatal_error)
 
 # Fix try_compile
-set(MACOSX_BUNDLE_GUI_IDENTIFIER com.example)
+include(polly_ios_bundle_identifier)
 set(CMAKE_MACOSX_BUNDLE YES)
 set(CMAKE_XCODE_ATTRIBUTE_CODE_SIGN_IDENTITY "iPhone Developer")
 

--- a/ios-9-2-hid.cmake
+++ b/ios-9-2-hid.cmake
@@ -27,7 +27,7 @@ include("${CMAKE_CURRENT_LIST_DIR}/utilities/polly_common.cmake")
 include(polly_fatal_error)
 
 # Fix try_compile
-set(MACOSX_BUNDLE_GUI_IDENTIFIER com.example)
+include(polly_ios_bundle_identifier)
 set(CMAKE_MACOSX_BUNDLE YES)
 set(CMAKE_XCODE_ATTRIBUTE_CODE_SIGN_IDENTITY "iPhone Developer")
 

--- a/ios-9-2.cmake
+++ b/ios-9-2.cmake
@@ -25,7 +25,7 @@ include("${CMAKE_CURRENT_LIST_DIR}/utilities/polly_common.cmake")
 include(polly_fatal_error)
 
 # Fix try_compile
-set(MACOSX_BUNDLE_GUI_IDENTIFIER com.example)
+include(polly_ios_bundle_identifier)
 set(CMAKE_MACOSX_BUNDLE YES)
 set(CMAKE_XCODE_ATTRIBUTE_CODE_SIGN_IDENTITY "iPhone Developer")
 

--- a/ios-9-3-arm64.cmake
+++ b/ios-9-3-arm64.cmake
@@ -26,7 +26,7 @@ include("${CMAKE_CURRENT_LIST_DIR}/utilities/polly_common.cmake")
 include(polly_fatal_error)
 
 # Fix try_compile
-set(MACOSX_BUNDLE_GUI_IDENTIFIER com.example)
+include(polly_ios_bundle_identifier)
 set(CMAKE_MACOSX_BUNDLE YES)
 set(CMAKE_XCODE_ATTRIBUTE_CODE_SIGN_IDENTITY "iPhone Developer")
 

--- a/ios-9-3-armv7.cmake
+++ b/ios-9-3-armv7.cmake
@@ -26,7 +26,7 @@ include("${CMAKE_CURRENT_LIST_DIR}/utilities/polly_common.cmake")
 include(polly_fatal_error)
 
 # Fix try_compile
-set(MACOSX_BUNDLE_GUI_IDENTIFIER com.example)
+include(polly_ios_bundle_identifier)
 set(CMAKE_MACOSX_BUNDLE YES)
 set(CMAKE_XCODE_ATTRIBUTE_CODE_SIGN_IDENTITY "iPhone Developer")
 

--- a/ios-9-3-wo-armv7s.cmake
+++ b/ios-9-3-wo-armv7s.cmake
@@ -26,7 +26,7 @@ include("${CMAKE_CURRENT_LIST_DIR}/utilities/polly_common.cmake")
 include(polly_fatal_error)
 
 # Fix try_compile
-set(MACOSX_BUNDLE_GUI_IDENTIFIER com.example)
+include(polly_ios_bundle_identifier)
 set(CMAKE_MACOSX_BUNDLE YES)
 set(CMAKE_XCODE_ATTRIBUTE_CODE_SIGN_IDENTITY "iPhone Developer")
 

--- a/ios-9-3.cmake
+++ b/ios-9-3.cmake
@@ -25,7 +25,7 @@ include("${CMAKE_CURRENT_LIST_DIR}/utilities/polly_common.cmake")
 include(polly_fatal_error)
 
 # Fix try_compile
-set(MACOSX_BUNDLE_GUI_IDENTIFIER com.example)
+include(polly_ios_bundle_identifier)
 set(CMAKE_MACOSX_BUNDLE YES)
 set(CMAKE_XCODE_ATTRIBUTE_CODE_SIGN_IDENTITY "iPhone Developer")
 

--- a/ios-nocodesign-10-0-arm64.cmake
+++ b/ios-nocodesign-10-0-arm64.cmake
@@ -26,7 +26,7 @@ include("${CMAKE_CURRENT_LIST_DIR}/utilities/polly_common.cmake")
 include(polly_fatal_error)
 
 # Fix try_compile
-set(MACOSX_BUNDLE_GUI_IDENTIFIER com.example)
+include(polly_ios_bundle_identifier)
 set(CMAKE_MACOSX_BUNDLE YES)
 
 # Verify XCODE_XCCONFIG_FILE

--- a/ios-nocodesign-10-0-armv7.cmake
+++ b/ios-nocodesign-10-0-armv7.cmake
@@ -26,7 +26,7 @@ include("${CMAKE_CURRENT_LIST_DIR}/utilities/polly_common.cmake")
 include(polly_fatal_error)
 
 # Fix try_compile
-set(MACOSX_BUNDLE_GUI_IDENTIFIER com.example)
+include(polly_ios_bundle_identifier)
 set(CMAKE_MACOSX_BUNDLE YES)
 
 # Verify XCODE_XCCONFIG_FILE

--- a/ios-nocodesign-10-0-wo-armv7s.cmake
+++ b/ios-nocodesign-10-0-wo-armv7s.cmake
@@ -26,7 +26,7 @@ include("${CMAKE_CURRENT_LIST_DIR}/utilities/polly_common.cmake")
 include(polly_fatal_error)
 
 # Fix try_compile
-set(MACOSX_BUNDLE_GUI_IDENTIFIER com.example)
+include(polly_ios_bundle_identifier)
 set(CMAKE_MACOSX_BUNDLE YES)
 
 # Verify XCODE_XCCONFIG_FILE

--- a/ios-nocodesign-10-0.cmake
+++ b/ios-nocodesign-10-0.cmake
@@ -26,7 +26,7 @@ include("${CMAKE_CURRENT_LIST_DIR}/utilities/polly_common.cmake")
 include(polly_fatal_error)
 
 # Fix try_compile
-set(MACOSX_BUNDLE_GUI_IDENTIFIER com.example)
+include(polly_ios_bundle_identifier)
 set(CMAKE_MACOSX_BUNDLE YES)
 
 # Verify XCODE_XCCONFIG_FILE

--- a/ios-nocodesign-10-1-arm64-dep-9-0-device-libcxx-hid-sections-lto.cmake
+++ b/ios-nocodesign-10-1-arm64-dep-9-0-device-libcxx-hid-sections-lto.cmake
@@ -30,7 +30,7 @@ include("${CMAKE_CURRENT_LIST_DIR}/utilities/polly_common.cmake")
 include(polly_fatal_error)
 
 # Fix try_compile
-set(MACOSX_BUNDLE_GUI_IDENTIFIER com.example)
+include(polly_ios_bundle_identifier)
 set(CMAKE_MACOSX_BUNDLE YES)
 
 # Verify XCODE_XCCONFIG_FILE

--- a/ios-nocodesign-10-1-arm64.cmake
+++ b/ios-nocodesign-10-1-arm64.cmake
@@ -26,7 +26,7 @@ include("${CMAKE_CURRENT_LIST_DIR}/utilities/polly_common.cmake")
 include(polly_fatal_error)
 
 # Fix try_compile
-set(MACOSX_BUNDLE_GUI_IDENTIFIER com.example)
+include(polly_ios_bundle_identifier)
 set(CMAKE_MACOSX_BUNDLE YES)
 
 # Verify XCODE_XCCONFIG_FILE

--- a/ios-nocodesign-10-1-armv7.cmake
+++ b/ios-nocodesign-10-1-armv7.cmake
@@ -26,7 +26,7 @@ include("${CMAKE_CURRENT_LIST_DIR}/utilities/polly_common.cmake")
 include(polly_fatal_error)
 
 # Fix try_compile
-set(MACOSX_BUNDLE_GUI_IDENTIFIER com.example)
+include(polly_ios_bundle_identifier)
 set(CMAKE_MACOSX_BUNDLE YES)
 
 # Verify XCODE_XCCONFIG_FILE

--- a/ios-nocodesign-10-1-dep-8-0-device-libcxx-hid-sections-lto.cmake
+++ b/ios-nocodesign-10-1-dep-8-0-device-libcxx-hid-sections-lto.cmake
@@ -30,7 +30,7 @@ include("${CMAKE_CURRENT_LIST_DIR}/utilities/polly_common.cmake")
 include(polly_fatal_error)
 
 # Fix try_compile
-set(MACOSX_BUNDLE_GUI_IDENTIFIER com.example)
+include(polly_ios_bundle_identifier)
 set(CMAKE_MACOSX_BUNDLE YES)
 
 # Verify XCODE_XCCONFIG_FILE

--- a/ios-nocodesign-10-1-dep-8-0-libcxx-hid-sections-lto.cmake
+++ b/ios-nocodesign-10-1-dep-8-0-libcxx-hid-sections-lto.cmake
@@ -30,7 +30,7 @@ include("${CMAKE_CURRENT_LIST_DIR}/utilities/polly_common.cmake")
 include(polly_fatal_error)
 
 # Fix try_compile
-set(MACOSX_BUNDLE_GUI_IDENTIFIER com.example)
+include(polly_ios_bundle_identifier)
 set(CMAKE_MACOSX_BUNDLE YES)
 
 # Verify XCODE_XCCONFIG_FILE

--- a/ios-nocodesign-10-1-dep-9-0-device-libcxx-hid-sections-lto.cmake
+++ b/ios-nocodesign-10-1-dep-9-0-device-libcxx-hid-sections-lto.cmake
@@ -30,7 +30,7 @@ include("${CMAKE_CURRENT_LIST_DIR}/utilities/polly_common.cmake")
 include(polly_fatal_error)
 
 # Fix try_compile
-set(MACOSX_BUNDLE_GUI_IDENTIFIER com.example)
+include(polly_ios_bundle_identifier)
 set(CMAKE_MACOSX_BUNDLE YES)
 
 # Verify XCODE_XCCONFIG_FILE

--- a/ios-nocodesign-10-1-wo-armv7s.cmake
+++ b/ios-nocodesign-10-1-wo-armv7s.cmake
@@ -26,7 +26,7 @@ include("${CMAKE_CURRENT_LIST_DIR}/utilities/polly_common.cmake")
 include(polly_fatal_error)
 
 # Fix try_compile
-set(MACOSX_BUNDLE_GUI_IDENTIFIER com.example)
+include(polly_ios_bundle_identifier)
 set(CMAKE_MACOSX_BUNDLE YES)
 
 # Verify XCODE_XCCONFIG_FILE

--- a/ios-nocodesign-10-1.cmake
+++ b/ios-nocodesign-10-1.cmake
@@ -26,7 +26,7 @@ include("${CMAKE_CURRENT_LIST_DIR}/utilities/polly_common.cmake")
 include(polly_fatal_error)
 
 # Fix try_compile
-set(MACOSX_BUNDLE_GUI_IDENTIFIER com.example)
+include(polly_ios_bundle_identifier)
 set(CMAKE_MACOSX_BUNDLE YES)
 
 # Verify XCODE_XCCONFIG_FILE

--- a/ios-nocodesign-10-2.cmake
+++ b/ios-nocodesign-10-2.cmake
@@ -26,7 +26,7 @@ include("${CMAKE_CURRENT_LIST_DIR}/utilities/polly_common.cmake")
 include(polly_fatal_error)
 
 # Fix try_compile
-set(MACOSX_BUNDLE_GUI_IDENTIFIER com.example)
+include(polly_ios_bundle_identifier)
 set(CMAKE_MACOSX_BUNDLE YES)
 
 # Verify XCODE_XCCONFIG_FILE

--- a/ios-nocodesign-10-3.cmake
+++ b/ios-nocodesign-10-3.cmake
@@ -26,7 +26,7 @@ include("${CMAKE_CURRENT_LIST_DIR}/utilities/polly_common.cmake")
 include(polly_fatal_error)
 
 # Fix try_compile
-set(MACOSX_BUNDLE_GUI_IDENTIFIER com.example)
+include(polly_ios_bundle_identifier)
 set(CMAKE_MACOSX_BUNDLE YES)
 
 # Verify XCODE_XCCONFIG_FILE

--- a/ios-nocodesign-8-4.cmake
+++ b/ios-nocodesign-8-4.cmake
@@ -26,7 +26,7 @@ include("${CMAKE_CURRENT_LIST_DIR}/utilities/polly_common.cmake")
 include(polly_fatal_error)
 
 # Fix try_compile
-set(MACOSX_BUNDLE_GUI_IDENTIFIER com.example)
+include(polly_ios_bundle_identifier)
 set(CMAKE_MACOSX_BUNDLE YES)
 
 # Verify XCODE_XCCONFIG_FILE

--- a/ios-nocodesign-9-1-arm64.cmake
+++ b/ios-nocodesign-9-1-arm64.cmake
@@ -26,7 +26,7 @@ include("${CMAKE_CURRENT_LIST_DIR}/utilities/polly_common.cmake")
 include(polly_fatal_error)
 
 # Fix try_compile
-set(MACOSX_BUNDLE_GUI_IDENTIFIER com.example)
+include(polly_ios_bundle_identifier)
 set(CMAKE_MACOSX_BUNDLE YES)
 
 # Verify XCODE_XCCONFIG_FILE

--- a/ios-nocodesign-9-1-armv7.cmake
+++ b/ios-nocodesign-9-1-armv7.cmake
@@ -26,7 +26,7 @@ include("${CMAKE_CURRENT_LIST_DIR}/utilities/polly_common.cmake")
 include(polly_fatal_error)
 
 # Fix try_compile
-set(MACOSX_BUNDLE_GUI_IDENTIFIER com.example)
+include(polly_ios_bundle_identifier)
 set(CMAKE_MACOSX_BUNDLE YES)
 
 # Verify XCODE_XCCONFIG_FILE

--- a/ios-nocodesign-9-1.cmake
+++ b/ios-nocodesign-9-1.cmake
@@ -26,7 +26,7 @@ include("${CMAKE_CURRENT_LIST_DIR}/utilities/polly_common.cmake")
 include(polly_fatal_error)
 
 # Fix try_compile
-set(MACOSX_BUNDLE_GUI_IDENTIFIER com.example)
+include(polly_ios_bundle_identifier)
 set(CMAKE_MACOSX_BUNDLE YES)
 
 # Verify XCODE_XCCONFIG_FILE

--- a/ios-nocodesign-9-2-arm64.cmake
+++ b/ios-nocodesign-9-2-arm64.cmake
@@ -26,7 +26,7 @@ include("${CMAKE_CURRENT_LIST_DIR}/utilities/polly_common.cmake")
 include(polly_fatal_error)
 
 # Fix try_compile
-set(MACOSX_BUNDLE_GUI_IDENTIFIER com.example)
+include(polly_ios_bundle_identifier)
 set(CMAKE_MACOSX_BUNDLE YES)
 
 # Verify XCODE_XCCONFIG_FILE

--- a/ios-nocodesign-9-2-armv7.cmake
+++ b/ios-nocodesign-9-2-armv7.cmake
@@ -26,7 +26,7 @@ include("${CMAKE_CURRENT_LIST_DIR}/utilities/polly_common.cmake")
 include(polly_fatal_error)
 
 # Fix try_compile
-set(MACOSX_BUNDLE_GUI_IDENTIFIER com.example)
+include(polly_ios_bundle_identifier)
 set(CMAKE_MACOSX_BUNDLE YES)
 
 # Verify XCODE_XCCONFIG_FILE

--- a/ios-nocodesign-9-2.cmake
+++ b/ios-nocodesign-9-2.cmake
@@ -26,7 +26,7 @@ include("${CMAKE_CURRENT_LIST_DIR}/utilities/polly_common.cmake")
 include(polly_fatal_error)
 
 # Fix try_compile
-set(MACOSX_BUNDLE_GUI_IDENTIFIER com.example)
+include(polly_ios_bundle_identifier)
 set(CMAKE_MACOSX_BUNDLE YES)
 
 # Verify XCODE_XCCONFIG_FILE

--- a/ios-nocodesign-9-3-arm64.cmake
+++ b/ios-nocodesign-9-3-arm64.cmake
@@ -26,7 +26,7 @@ include("${CMAKE_CURRENT_LIST_DIR}/utilities/polly_common.cmake")
 include(polly_fatal_error)
 
 # Fix try_compile
-set(MACOSX_BUNDLE_GUI_IDENTIFIER com.example)
+include(polly_ios_bundle_identifier)
 set(CMAKE_MACOSX_BUNDLE YES)
 
 # Verify XCODE_XCCONFIG_FILE

--- a/ios-nocodesign-9-3-armv7.cmake
+++ b/ios-nocodesign-9-3-armv7.cmake
@@ -26,7 +26,7 @@ include("${CMAKE_CURRENT_LIST_DIR}/utilities/polly_common.cmake")
 include(polly_fatal_error)
 
 # Fix try_compile
-set(MACOSX_BUNDLE_GUI_IDENTIFIER com.example)
+include(polly_ios_bundle_identifier)
 set(CMAKE_MACOSX_BUNDLE YES)
 
 # Verify XCODE_XCCONFIG_FILE

--- a/ios-nocodesign-9-3-device-hid-sections.cmake
+++ b/ios-nocodesign-9-3-device-hid-sections.cmake
@@ -27,7 +27,7 @@ include("${CMAKE_CURRENT_LIST_DIR}/utilities/polly_common.cmake")
 include(polly_fatal_error)
 
 # Fix try_compile
-set(MACOSX_BUNDLE_GUI_IDENTIFIER com.example)
+include(polly_ios_bundle_identifier)
 set(CMAKE_MACOSX_BUNDLE YES)
 
 # Verify XCODE_XCCONFIG_FILE

--- a/ios-nocodesign-9-3-device.cmake
+++ b/ios-nocodesign-9-3-device.cmake
@@ -26,7 +26,7 @@ include("${CMAKE_CURRENT_LIST_DIR}/utilities/polly_common.cmake")
 include(polly_fatal_error)
 
 # Fix try_compile
-set(MACOSX_BUNDLE_GUI_IDENTIFIER com.example)
+include(polly_ios_bundle_identifier)
 set(CMAKE_MACOSX_BUNDLE YES)
 
 # Verify XCODE_XCCONFIG_FILE

--- a/ios-nocodesign-9-3-wo-armv7s.cmake
+++ b/ios-nocodesign-9-3-wo-armv7s.cmake
@@ -26,7 +26,7 @@ include("${CMAKE_CURRENT_LIST_DIR}/utilities/polly_common.cmake")
 include(polly_fatal_error)
 
 # Fix try_compile
-set(MACOSX_BUNDLE_GUI_IDENTIFIER com.example)
+include(polly_ios_bundle_identifier)
 set(CMAKE_MACOSX_BUNDLE YES)
 
 # Verify XCODE_XCCONFIG_FILE

--- a/ios-nocodesign-9-3.cmake
+++ b/ios-nocodesign-9-3.cmake
@@ -26,7 +26,7 @@ include("${CMAKE_CURRENT_LIST_DIR}/utilities/polly_common.cmake")
 include(polly_fatal_error)
 
 # Fix try_compile
-set(MACOSX_BUNDLE_GUI_IDENTIFIER com.example)
+include(polly_ios_bundle_identifier)
 set(CMAKE_MACOSX_BUNDLE YES)
 
 # Verify XCODE_XCCONFIG_FILE

--- a/ios-nocodesign-arm64.cmake
+++ b/ios-nocodesign-arm64.cmake
@@ -26,7 +26,7 @@ include("${CMAKE_CURRENT_LIST_DIR}/utilities/polly_common.cmake")
 include(polly_fatal_error)
 
 # Fix try_compile
-set(MACOSX_BUNDLE_GUI_IDENTIFIER com.example)
+include(polly_ios_bundle_identifier)
 set(CMAKE_MACOSX_BUNDLE YES)
 
 # Verify XCODE_XCCONFIG_FILE

--- a/ios-nocodesign-armv7.cmake
+++ b/ios-nocodesign-armv7.cmake
@@ -26,7 +26,7 @@ include("${CMAKE_CURRENT_LIST_DIR}/utilities/polly_common.cmake")
 include(polly_fatal_error)
 
 # Fix try_compile
-set(MACOSX_BUNDLE_GUI_IDENTIFIER com.example)
+include(polly_ios_bundle_identifier)
 set(CMAKE_MACOSX_BUNDLE YES)
 
 # Verify XCODE_XCCONFIG_FILE

--- a/ios-nocodesign-hid-sections.cmake
+++ b/ios-nocodesign-hid-sections.cmake
@@ -27,7 +27,7 @@ include("${CMAKE_CURRENT_LIST_DIR}/utilities/polly_common.cmake")
 include(polly_fatal_error)
 
 # Fix try_compile
-set(MACOSX_BUNDLE_GUI_IDENTIFIER com.example)
+include(polly_ios_bundle_identifier)
 set(CMAKE_MACOSX_BUNDLE YES)
 
 # Verify XCODE_XCCONFIG_FILE

--- a/ios-nocodesign-wo-armv7s.cmake
+++ b/ios-nocodesign-wo-armv7s.cmake
@@ -26,7 +26,7 @@ include("${CMAKE_CURRENT_LIST_DIR}/utilities/polly_common.cmake")
 include(polly_fatal_error)
 
 # Fix try_compile
-set(MACOSX_BUNDLE_GUI_IDENTIFIER com.example)
+include(polly_ios_bundle_identifier)
 set(CMAKE_MACOSX_BUNDLE YES)
 
 # Verify XCODE_XCCONFIG_FILE

--- a/ios-nocodesign.cmake
+++ b/ios-nocodesign.cmake
@@ -26,7 +26,7 @@ include("${CMAKE_CURRENT_LIST_DIR}/utilities/polly_common.cmake")
 include(polly_fatal_error)
 
 # Fix try_compile
-set(MACOSX_BUNDLE_GUI_IDENTIFIER com.example)
+include(polly_ios_bundle_identifier)
 set(CMAKE_MACOSX_BUNDLE YES)
 
 # Verify XCODE_XCCONFIG_FILE

--- a/utilities/polly_ios_bundle_identifier.cmake
+++ b/utilities/polly_ios_bundle_identifier.cmake
@@ -1,0 +1,21 @@
+# Copyright (c) 2016, Ruslan Baratov
+# All rights reserved.
+
+if(DEFINED POLLY_UTILITIES_POLLY_IOS_BUNDLE_IDENTIFIER_CMAKE_)
+  return()
+else()
+  set(POLLY_UTILITIES_POLLY_IOS_BUNDLE_IDENTIFIER_CMAKE_ 1)
+endif()
+
+include(polly_status_debug)
+
+string(COMPARE EQUAL "$ENV{POLLY_IOS_BUNDLE_IDENTIFIER}" "" _is_empty)  
+if(_is_empty)
+  set(MACOSX_BUNDLE_GUI_IDENTIFIER "com.example") 
+else()
+  set(MACOSX_BUNDLE_GUI_IDENTIFIER $ENV{POLLY_IOS_BUNDLE_IDENTIFIER})
+endif()
+
+polly_status_debug(
+    "Using Xcode bundle identifier: ${MACOSX_BUNDLE_GUI_IDENTIFIER}"
+)


### PR DESCRIPTION
Due to the bundle identifier `com.example` not being available for Apple Enterprise accounts to register.
We would like to introduce a variable, which defaults to `com.example`, in the try-compile for ios cmake files.
To allow for any bundle identifier to be used on the try-compile function.