### PR TITLE
Update ios-nocodesign-10-3-dep-9-0-bitcode.cmake

### DIFF
--- a/ios-nocodesign-10-3-dep-9-0-bitcode.cmake
+++ b/ios-nocodesign-10-3-dep-9-0-bitcode.cmake
@@ -70,5 +70,3 @@ include("${CMAKE_CURRENT_LIST_DIR}/compiler/xcode.cmake")
 include("${CMAKE_CURRENT_LIST_DIR}/os/iphone.cmake")
 include("${CMAKE_CURRENT_LIST_DIR}/flags/cxx11.cmake")
 include("${CMAKE_CURRENT_LIST_DIR}/flags/bitcode.cmake") # after os/iphone.cmake
-
-include("${CMAKE_CURRENT_LIST_DIR}/utilities/polly_ios_development_team.cmake")


### PR DESCRIPTION
nocodesign should not invoke the IOS development team dependency