### PR TITLE
Ios11

### DIFF
--- a/flags/cxx14.cmake
+++ b/flags/cxx14.cmake
@@ -1,0 +1,19 @@
+# Copyright (c) 2013, Ruslan Baratov
+# All rights reserved.
+
+if(DEFINED POLLY_FLAGS_CXX14_CMAKE)
+return()
+else()
+set(POLLY_FLAGS_CXX14_CMAKE 1)
+endif()
+
+include(polly_add_cache_flag)
+
+string(COMPARE EQUAL "${ANDROID_NDK_VERSION}" "" _not_android)
+
+# TODO: test other platfroms, CMAKE_CXX_FLAGS_INIT should work for all
+if(_not_android)
+polly_add_cache_flag(CMAKE_CXX_FLAGS "-std=c++14")
+else()
+polly_add_cache_flag(CMAKE_CXX_FLAGS_INIT "-std=c++14")
+endif()

--- a/ios-11-0.cmake
+++ b/ios-11-0.cmake
@@ -1,0 +1,40 @@
+# Copyright (c) 2016, Ruslan Baratov
+# All rights reserved.
+
+if(DEFINED POLLY_IOS_11_0_CMAKE_)
+return()
+else()
+set(POLLY_IOS_11_0_CMAKE_ 1)
+endif()
+
+include("${CMAKE_CURRENT_LIST_DIR}/utilities/polly_clear_environment_variables.cmake")
+
+include("${CMAKE_CURRENT_LIST_DIR}/utilities/polly_init.cmake")
+
+set(IOS_SDK_VERSION 11.0)
+set(POLLY_XCODE_COMPILER "clang")
+polly_init(
+  "iOS ${IOS_SDK_VERSION} Universal (iphoneos + iphonesimulator) / \
+${POLLY_XCODE_COMPILER} / \
+c++14 support"
+  "Xcode"
+)
+
+include("${CMAKE_CURRENT_LIST_DIR}/utilities/polly_common.cmake")
+
+include(polly_fatal_error)
+
+# Fix try_compile
+include(polly_ios_bundle_identifier)
+
+set(CMAKE_MACOSX_BUNDLE YES)
+set(CMAKE_XCODE_ATTRIBUTE_CODE_SIGN_IDENTITY "iPhone Developer")
+
+set(IPHONEOS_ARCHS arm64)
+set(IPHONESIMULATOR_ARCHS x86_64)
+
+include("${CMAKE_CURRENT_LIST_DIR}/compiler/xcode.cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/os/iphone.cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/flags/cxx14.cmake")
+
+include("${CMAKE_CURRENT_LIST_DIR}/utilities/polly_ios_development_team.cmake")

--- a/ios-nocodesign-11-0.cmake
+++ b/ios-nocodesign-11-0.cmake
@@ -1,0 +1,67 @@
+# Copyright (c) 2014-2016, Ruslan Baratov
+# All rights reserved.
+
+if(DEFINED POLLY_IOS_NOCODESIGN_11_0_CMAKE_)
+return()
+else()
+set(POLLY_IOS_NOCODESIGN_11_0_CMAKE_ 1)
+endif()
+
+include("${CMAKE_CURRENT_LIST_DIR}/utilities/polly_clear_environment_variables.cmake")
+
+include("${CMAKE_CURRENT_LIST_DIR}/utilities/polly_init.cmake")
+
+set(IOS_SDK_VERSION 11.0)
+set(POLLY_XCODE_COMPILER "clang")
+polly_init(
+  "iOS ${IOS_SDK_VERSION} Universal (iphoneos + iphonesimulator) / \
+${POLLY_XCODE_COMPILER} / \
+No code sign / \
+c++14 support"
+  "Xcode"
+)
+
+include("${CMAKE_CURRENT_LIST_DIR}/utilities/polly_common.cmake")
+
+include(polly_fatal_error)
+
+# Fix try_compile
+include(polly_ios_bundle_identifier)
+set(CMAKE_MACOSX_BUNDLE YES)
+
+# Verify XCODE_XCCONFIG_FILE
+set(
+  _polly_xcode_xcconfig_file_path
+  "${CMAKE_CURRENT_LIST_DIR}/scripts/NoCodeSign.xcconfig"
+)
+if(NOT EXISTS "$ENV{XCODE_XCCONFIG_FILE}")
+polly_fatal_error(
+    "Path specified by XCODE_XCCONFIG_FILE environment variable not found"
+    "($ENV{XCODE_XCCONFIG_FILE})"
+    "Use this command to set: "
+    "    export XCODE_XCCONFIG_FILE=${_polly_xcode_xcconfig_file_path}"
+)
+else()
+string(
+    COMPARE
+    NOTEQUAL
+    "$ENV{XCODE_XCCONFIG_FILE}"
+    "${_polly_xcode_xcconfig_file_path}"
+    _polly_wrong_xcconfig_path
+)
+if(_polly_wrong_xcconfig_path)
+  polly_fatal_error(
+      "Unexpected XCODE_XCCONFIG_FILE value: "
+      "    $ENV{XCODE_XCCONFIG_FILE}"
+      "expected: "
+      "    ${_polly_xcode_xcconfig_file_path}"
+  )
+endif()
+endif()
+
+set(IPHONEOS_ARCHS arm64)
+set(IPHONESIMULATOR_ARCHS x86_64)
+
+include("${CMAKE_CURRENT_LIST_DIR}/compiler/xcode.cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/os/iphone.cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/flags/cxx14.cmake")


### PR DESCRIPTION
Hi 

This is a pull request that tries to add support for iOS 11 (since iOS 11 removes support for 32 bits app). I do not know if you were already working on it on your side.
It was succesfully tested on my with a Mac that has the newest XCode 9.0 installed, andl only iPhone11 sdk.

PS : I am sorry if this PR mixes cxx14 and iOS11 

Summary : added `flags/cxx14.make`, added `ios-11-0.cmake` and `ios-nocodesign-11-0.cmake` 

Main differences : 
* use flags/cxx14.cmake 
* removed armv7 and armv7s support since 32 bits is not supported anymore by iOS 11 
* also removed simulator arch i386 in favor of the 64 bits simulator arch x86_64

Notes : 
* I left`ios-nocodesign.cmake` unchanged, but it still refers to an older sdk (iOS8.1)
* I wondered if it would be a good idea to add a toolchain ios-latest.cmake that would automatically search for the highest SDK inside /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/
What do you think ?

