### PR TITLE
 POLLY_IOS_DEVELOPMENT_TEAM can also be a cmake variable

### DIFF
--- a/utilities/polly_ios_bundle_identifier.cmake
+++ b/utilities/polly_ios_bundle_identifier.cmake
@@ -9,11 +9,17 @@ endif()
 
 include(polly_status_debug)
 
-string(COMPARE EQUAL "$ENV{POLLY_IOS_BUNDLE_IDENTIFIER}" "" _is_empty)  
-if(_is_empty)
-  set(MACOSX_BUNDLE_GUI_IDENTIFIER "com.example") 
+# POLLY_IOS_BUNDLE_IDENTIFIER can be set either through an environment variable 
+# or through a regular cmake variable
+if (NOT POLLY_IOS_BUNDLE_IDENTIFIER)
+  string(COMPARE EQUAL "$ENV{POLLY_IOS_BUNDLE_IDENTIFIER}" "" _is_empty)  
+  if(_is_empty)
+    set(MACOSX_BUNDLE_GUI_IDENTIFIER "com.example") 
+  else()
+    set(MACOSX_BUNDLE_GUI_IDENTIFIER $ENV{POLLY_IOS_BUNDLE_IDENTIFIER})
+  endif()
 else()
-  set(MACOSX_BUNDLE_GUI_IDENTIFIER $ENV{POLLY_IOS_BUNDLE_IDENTIFIER})
+  set(MACOSX_BUNDLE_GUI_IDENTIFIER ${POLLY_IOS_BUNDLE_IDENTIFIER})
 endif()
 
 polly_status_debug(

--- a/utilities/polly_ios_development_team.cmake
+++ b/utilities/polly_ios_development_team.cmake
@@ -10,18 +10,21 @@ endif()
 include("${CMAKE_CURRENT_LIST_DIR}/polly_fatal_error.cmake")
 include("${CMAKE_CURRENT_LIST_DIR}/polly_status_debug.cmake")
 
-string(COMPARE EQUAL "$ENV{POLLY_IOS_DEVELOPMENT_TEAM}" "" _is_empty)
-if(_is_empty)
-  polly_fatal_error(
-      "Environment variable POLLY_IOS_DEVELOPMENT_TEAM is empty"
-      " (see details: http://polly.readthedocs.io/en/latest/toolchains/ios/errors/polly_ios_development_team.html)"
-  )
+# POLLY_IOS_DEVELOPMENT_TEAM can be set either through an environment variable 
+# or through a regular cmake variable
+if (POLLY_IOS_DEVELOPMENT_TEAM)
+  set(CMAKE_XCODE_ATTRIBUTE_DEVELOPMENT_TEAM "${POLLY_IOS_DEVELOPMENT_TEAM}")
+else()
+  string(COMPARE EQUAL "$ENV{POLLY_IOS_DEVELOPMENT_TEAM}" "" _is_empty)
+  if(_is_empty)
+    polly_fatal_error(
+        "Environment variable POLLY_IOS_DEVELOPMENT_TEAM is empty"
+        " (see details: http://polly.readthedocs.io/en/latest/toolchains/ios/errors/polly_ios_development_team.html)"
+    )
+  endif()
+  set(CMAKE_XCODE_ATTRIBUTE_DEVELOPMENT_TEAM "$ENV{POLLY_IOS_DEVELOPMENT_TEAM}")
 endif()
 
-set(
-    CMAKE_XCODE_ATTRIBUTE_DEVELOPMENT_TEAM
-    "$ENV{POLLY_IOS_DEVELOPMENT_TEAM}"
-)
 
 polly_status_debug(
     "Using iOS development team id: ${CMAKE_XCODE_ATTRIBUTE_DEVELOPMENT_TEAM}"


### PR DESCRIPTION
POLLY_IOS_BUNDLE_IDENTIFIER and POLLY_IOS_DEVELOPMENT_TEAM can be set
 either through an environment variable or through a regular cmake variable

 This enables to create a wrapper toolchain that includes these variables i.e for example:

````
set(POLLY_IOS_DEVELOPMENT_TEAM "XXXXXX")
set(POLLY_IOS_BUNDLE_IDENTIFIER "com.example.pollyenabler")
include("${CMAKE_CURRENT_LIST_DIR}/polly-toolchains/ios-11-0.cmake")
`````
