### PR TITLE
add openbsd-egcc-cxx11-static-std toolchain

### DIFF
--- a/bin/detail/toolchain_table.py
+++ b/bin/detail/toolchain_table.py
@@ -463,6 +463,7 @@ if os.name == 'posix':
       Toolchain('libcxx-hid-sections', 'Unix Makefiles'),
       Toolchain('sanitize-address', 'Unix Makefiles'),
       Toolchain('arm-openwrt-linux-muslgnueabi', 'Unix Makefiles'),
+      Toolchain('openbsd-egcc-cxx11-static-std', 'Unix Makefiles'),
   ]
 
 def get_by_name(name):

--- a/compiler/egcc.cmake
+++ b/compiler/egcc.cmake
@@ -1,0 +1,47 @@
+# Copyright (c) 2013, Ruslan Baratov
+# All rights reserved.
+
+if(DEFINED POLLY_COMPILER_EGCC_CMAKE)
+  return()
+else()
+  set(POLLY_COMPILER_EGCC_CMAKE 1)
+endif()
+
+include(polly_fatal_error)
+
+if(XCODE_VERSION)
+  set(_err "This toolchain is not available for Xcode")
+  set(_err "${_err} because Xcode ignores CMAKE_C(XX)_COMPILER variable.")
+  set(_err "${_err} Use xcode.cmake toolchain instead.")
+  polly_fatal_error(${_err})
+endif()
+
+find_program(CMAKE_C_COMPILER egcc)
+find_program(CMAKE_CXX_COMPILER eg++)
+find_program(CMAKE_CPP_COMPILER egcpp)
+
+if(NOT CMAKE_C_COMPILER)
+  polly_fatal_error("egcc not found")
+endif()
+
+if(NOT CMAKE_CXX_COMPILER)
+  polly_fatal_error("eg++ not found")
+endif()
+
+set(
+    CMAKE_C_COMPILER
+    "${CMAKE_C_COMPILER}"
+    CACHE
+    STRING
+    "C compiler"
+    FORCE
+)
+
+set(
+    CMAKE_CXX_COMPILER
+    "${CMAKE_CXX_COMPILER}"
+    CACHE
+    STRING
+    "C++ compiler"
+    FORCE
+)

--- a/openbsd-egcc-cxx11-static-std.cmake
+++ b/openbsd-egcc-cxx11-static-std.cmake
@@ -1,0 +1,24 @@
+# Copyright (c) 2013, Ruslan Baratov
+# All rights reserved.
+
+if(DEFINED POLLY_CLANG_OPENBSD_CMAKE)
+  return()
+else()
+  set(POLLY_CLANG_OPENBSD_CMAKE 1)
+endif()
+
+include("${CMAKE_CURRENT_LIST_DIR}/utilities/polly_init.cmake")
+
+polly_init(
+    "openbsd / egcc / GNU Standard C++ Library (libstdc++) / c++11 support"
+    "Unix Makefiles"
+)
+
+include("${CMAKE_CURRENT_LIST_DIR}/utilities/polly_common.cmake")
+
+include("${CMAKE_CURRENT_LIST_DIR}/compiler/egcc.cmake")
+#include("${CMAKE_CURRENT_LIST_DIR}/library/std/libstdcxx.cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/flags/cxx11.cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/flags/fpic.cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/flags/static-std.cmake")
+


### PR DESCRIPTION
OpenBSD's default GCC is 4.2.1, so we need to use egcc/eg++ to build shared library. References: https://github.com/bitcoin/bitcoin/blob/master/doc/build-openbsd.md