### PR TITLE
ios-nocodesign-11-1-dep-9-0-wo-armv7s-bitcode-cxx11 toolchain added

### DIFF
--- a/bin/detail/toolchain_table.py
+++ b/bin/detail/toolchain_table.py
@@ -396,6 +396,7 @@ if platform.system() == 'Darwin':
       Toolchain('ios-nocodesign-11-0-dep-9-0-bitcode-cxx11', 'Xcode', ios_version='11.0', nocodesign=True),
       Toolchain('ios-nocodesign-11-0-arm64-dep-9-0-device-libcxx-hid-sections', 'Xcode', ios_version='11.0', nocodesign=True),
       Toolchain('ios-nocodesign-11-1', 'Xcode', ios_version='11.1', nocodesign=True),
+      Toolchain('ios-nocodesign-11-1-dep-9-0-wo-armv7s-bitcode-cxx11', 'Xcode', ios_version='11.1', nocodesign=True),
       Toolchain('xcode', 'Xcode'),
       Toolchain('xcode-cxx98', 'Xcode'),
       Toolchain('xcode-nocxx', 'Xcode'),

--- a/ios-nocodesign-11-1-dep-9-0-wo-armv7s-bitcode-cxx11.cmake
+++ b/ios-nocodesign-11-1-dep-9-0-wo-armv7s-bitcode-cxx11.cmake
@@ -1,0 +1,45 @@
+# Copyright (c) 2017, Ruslan Baratov
+# All rights reserved.
+
+if(DEFINED POLLY_IOS_NOCODESIGN_11_1_DEP_9_0_WO_ARMV7S_BITCODE_CXX11_CMAKE_)
+  return()
+else()
+  set(POLLY_IOS_NOCODESIGN_11_1_DEP_9_0_WO_ARMV7S_BITCODE_CXX11_CMAKE_ 1)
+endif()
+
+include("${CMAKE_CURRENT_LIST_DIR}/utilities/polly_clear_environment_variables.cmake")
+
+include("${CMAKE_CURRENT_LIST_DIR}/utilities/polly_init.cmake")
+
+set(IOS_SDK_VERSION 11.1)
+set(IOS_DEPLOYMENT_SDK_VERSION 9.0)
+
+set(POLLY_XCODE_COMPILER "clang")
+polly_init(
+    "iOS ${IOS_SDK_VERSION} / Deployment ${IOS_DEPLOYMENT_SDK_VERSION} / Universal (iphoneos + iphonesimulator) / \
+armv7 arm64 / i386 x86_64 / \
+${POLLY_XCODE_COMPILER} / \
+No code sign / \
+bitcode / \
+c++11 support"
+    "Xcode"
+)
+
+include("${CMAKE_CURRENT_LIST_DIR}/utilities/polly_common.cmake")
+
+include(polly_fatal_error)
+
+# Fix try_compile
+include(polly_ios_bundle_identifier)
+
+set(CMAKE_MACOSX_BUNDLE YES)
+
+include("${CMAKE_CURRENT_LIST_DIR}/flags/ios_nocodesign.cmake")
+
+set(IPHONEOS_ARCHS armv7;arm64)
+set(IPHONESIMULATOR_ARCHS i386;x86_64)
+
+include("${CMAKE_CURRENT_LIST_DIR}/compiler/xcode.cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/os/iphone.cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/flags/cxx11.cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/flags/bitcode.cmake") # after os/iphone.cmake


### PR DESCRIPTION
Hi, I hope I did not miss any of common sense conventions :)

One note I added include("${CMAKE_CURRENT_LIST_DIR}/flags/cxx11.cmake")
It causes doubling --std=c++11 --std=c++11 for compiler.
When I do not add the include it put to compile flags --std=c++11 by default.
I did not want to break convention iOS >= 11.0 cxx14 by default.
Doubling shall not affect building.

Best,
Stefan