### PR TITLE
add generic clang + libcxx toolchain with -std=c++14

### DIFF
--- a/bin/detail/toolchain_table.py
+++ b/bin/detail/toolchain_table.py
@@ -490,6 +490,7 @@ if os.name == 'posix':
       Toolchain('gcc-cxx98', 'Unix Makefiles'),
       Toolchain('gcc-lto', 'Unix Makefiles'),
       Toolchain('libcxx', 'Unix Makefiles'),
+      Toolchain('libcxx14', 'Unix Makefiles'),
       Toolchain('libcxx-no-sdk', 'Unix Makefiles'),
       Toolchain('libcxx-hid', 'Unix Makefiles'),
       Toolchain('libcxx-hid-fpic', 'Unix Makefiles'),

--- a/libcxx14.cmake
+++ b/libcxx14.cmake
@@ -1,0 +1,24 @@
+# Copyright (c) 2013-2018, Ruslan Baratov
+# Copyright (c) 2018, David Hirvonen
+# All rights reserved.
+
+if(DEFINED POLLY_CLANG_LIBCXX_CXX14_CMAKE)
+  return()
+else()
+  set(POLLY_CLANG_LIBCXX_CXX14_CMAKE 1)
+endif()
+
+include("${CMAKE_CURRENT_LIST_DIR}/utilities/polly_init.cmake")
+
+polly_init(
+    "clang / LLVM Standard C++ Library (libc++) / c++14 support"
+    "Unix Makefiles"
+)
+
+include("${CMAKE_CURRENT_LIST_DIR}/utilities/polly_common.cmake")
+
+include("${CMAKE_CURRENT_LIST_DIR}/compiler/clang.cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/library/std/libcxx.cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/flags/cxx14.cmake")
+
+include("${CMAKE_CURRENT_LIST_DIR}/os/osx.cmake")


### PR DESCRIPTION
This is similar to the libcxx.cmake toolchain but with a c++14 language flag.  It works with the default OSX Apple clang, for example, which has no versioned naming convention used by the llvm builds (i.e., clang-5).