### PR TITLE
Suppress unzip output (cmake) for Appveyor. 

### DIFF
--- a/bin/install-ci-dependencies.py
+++ b/bin/install-ci-dependencies.py
@@ -13,6 +13,7 @@ import stat
 import subprocess
 import sys
 import tarfile
+import tempfile
 import time
 import zipfile
 

--- a/bin/install-ci-dependencies.py
+++ b/bin/install-ci-dependencies.py
@@ -94,7 +94,8 @@ class FileToDownload:
     elif self.url.endswith('.zip'):
       # Can't use ZipFile module because permissions will be lost, see bug:
       # * https://bugs.python.org/issue15795
-      subprocess.check_call(['unzip', self.local_path])
+      w = tempfile.NamedTemporaryFile()
+      subprocess.check_call(['unzip', self.local_path], stdout=w, stderr=w, bufsize=0)
     elif self.url.endswith('.bin'):
       os.chmod(self.local_path, os.stat(self.local_path).st_mode | stat.S_IEXEC)
       devnull = open(os.devnull, 'w') # subprocess.DEVNULL is not available for Python 3.2


### PR DESCRIPTION
Travis explodes a tarball, but Appveyor dumps 1000+ lines when unzipping cmake, debugging build errors almost always required me to download the raw logs versus using the web interface.   This PR suppresses the unzip output.  

https://travis-ci.org/ckaminski/polly/builds/343881298
https://ci.appveyor.com/project/ckaminski/polly/build/1.0.44

Appveyor output:  ~line 22-28
```
File not exists: C:\projects\polly\_ci\cmake-3.10.2-win64-x64.zip
Downloading:
  https://github.com/ruslo/CMake/releases/download/v3.10.2/cmake-3.10.2-win64-x64.zip
  -> C:\projects\polly\_ci\cmake-3.10.2-win64-x64.zip
Done
Unpacking C:\projects\polly\_ci\cmake-3.10.2-win64-x64.zip
set PATH=%cd%\_ci\cmake\bin;%PATH%
```