### PR TITLE
android ndk r16b gcc + libc++ toolchain for LTO for MinSizeRel builds

### DIFF
--- a/android-ndk-r16b-api-19-armeabi-v7a-neon-hid-sections-lto.cmake
+++ b/android-ndk-r16b-api-19-armeabi-v7a-neon-hid-sections-lto.cmake
@@ -1,0 +1,43 @@
+# Copyright (c) 2015-2018, Ruslan Baratov
+# Copyright (c) 2015-2018, David Hirvonen
+# Copyright (c) 2015-2018, Alexandre Pretyman
+# All rights reserved.
+
+if(DEFINED POLLY_ANDROID_NDK_R16B_API_19_ARMEABI_V7A_NEON_HID_SECTIONS_LTO_CMAKE_)
+  return()
+else()
+  set(POLLY_ANDROID_NDK_R16B_API_19_ARMEABI_V7A_NEON_HID_SECTIONS_LTO_CMAKE_ 1)
+endif()
+
+include("${CMAKE_CURRENT_LIST_DIR}/utilities/polly_clear_environment_variables.cmake")
+
+include("${CMAKE_CURRENT_LIST_DIR}/utilities/polly_init.cmake")
+
+set(ANDROID_NDK_VERSION "r16b")
+set(CMAKE_SYSTEM_VERSION "19")
+set(CMAKE_ANDROID_ARCH_ABI "armeabi-v7a")
+set(CMAKE_ANDROID_ARM_NEON TRUE)
+set(CMAKE_ANDROID_ARM_MODE TRUE) # 32-bit ARM
+set(CMAKE_ANDROID_NDK_TOOLCHAIN_VERSION "4.9") # <major>.<minor>: GCC of specified version
+set(CMAKE_ANDROID_STL_TYPE "c++_static") # LLVM libc++ static
+
+polly_init(
+    "Android NDK ${ANDROID_NDK_VERSION} / \
+API ${CMAKE_SYSTEM_VERSION} / ${CMAKE_ANDROID_ARCH_ABI} / \
+NEON / 32-bit ARM / c++11 support / hidden / function-sections / data-sections / LTO"
+    "Unix Makefiles"
+)
+
+include("${CMAKE_CURRENT_LIST_DIR}/utilities/polly_common.cmake")
+
+include("${CMAKE_CURRENT_LIST_DIR}/flags/cxx11.cmake") # before toolchain!
+
+include("${CMAKE_CURRENT_LIST_DIR}/flags/function-sections.cmake")
+
+include("${CMAKE_CURRENT_LIST_DIR}/flags/data-sections.cmake")
+
+include("${CMAKE_CURRENT_LIST_DIR}/flags/hidden.cmake")
+
+include("${CMAKE_CURRENT_LIST_DIR}/os/android.cmake")
+
+include("${CMAKE_CURRENT_LIST_DIR}/flags/lto.cmake") # after 'os/android.cmake'

--- a/bin/detail/toolchain_table.py
+++ b/bin/detail/toolchain_table.py
@@ -135,6 +135,7 @@ toolchain_table = [
     Toolchain('android-ndk-r15c-api-21-x86-clang-libcxx', 'Unix Makefiles'),
     Toolchain('android-ndk-r15c-api-24-armeabi-v7a-neon-clang-libcxx', 'Unix Makefiles'),
     Toolchain('android-ndk-r16b-api-16-armeabi-v7a-clang-libcxx14', 'Unix Makefiles'),
+    Toolchain('android-ndk-r16b-api-19-armeabi-v7a-neon-hid-sections-lto', 'Unix Makefiles'),
     Toolchain('android-ndk-r16b-api-21-armeabi-clang-libcxx', 'Unix Makefiles'),
     Toolchain('android-ndk-r16b-api-21-armeabi-clang-libcxx14', 'Unix Makefiles'),
     Toolchain('android-ndk-r16b-api-21-armeabi-v7a-clang-libcxx', 'Unix Makefiles'),


### PR DESCRIPTION
NOTE: ndk 17-beta1 still doesn’t support LTO + MinSizeRel builds

It reports:
> "Optimization level must be between 0 and 3"

gcc + libcxx seems to be workable, but this combination can define an “unwind” symbol twice, which can be ignored with the following in the top level project target:

```
set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,--allow-multiple-definition")
```