### PR TITLE
Add cross Linux mingw gnuxx11

### DIFF
--- a/flags/gnuxx11.cmake
+++ b/flags/gnuxx11.cmake
@@ -1,0 +1,12 @@
+# Copyright (c) 2018, NeroBurner
+# All rights reserved.
+
+if(DEFINED POLLY_FLAGS_GNUXX11_CMAKE)
+  return()
+else()
+  set(POLLY_FLAGS_GNUXX11_CMAKE 1)
+endif()
+
+include(polly_add_cache_flag)
+
+polly_add_cache_flag(CMAKE_CXX_FLAGS "-std=gnu++11")

--- a/linux-mingw-w64-gnuxx11.cmake
+++ b/linux-mingw-w64-gnuxx11.cmake
@@ -1,0 +1,28 @@
+# Copyright (c) 2017, NeroBurner
+# All rights reserved.
+
+if(DEFINED POLLY_LINUX_MINGW_W64_GNUXX11_)
+  return()
+else()
+  set(POLLY_LINUX_MINGW_W64_GNUXX11_ 1)
+endif()
+
+include("${CMAKE_CURRENT_LIST_DIR}/utilities/polly_init.cmake")
+
+polly_init(
+    "Windows / mingw-w64 / x86_64 / gnu++11 support"
+    "Unix Makefiles"
+)
+
+include("${CMAKE_CURRENT_LIST_DIR}/utilities/polly_common.cmake")
+
+# need to set system name for cross compiling from linux to windows
+set(CMAKE_SYSTEM_NAME Windows)
+set(CROSS_COMPILE_TOOLCHAIN_PREFIX "x86_64-w64-mingw32")
+set(CMAKE_CROSSCOMPILING_EMULATOR wine64) # used for try_run calls
+
+include(
+    "${CMAKE_CURRENT_LIST_DIR}/compiler/gcc-cross-compile-simple-layout.cmake"
+)
+include("${CMAKE_CURRENT_LIST_DIR}/flags/gnuxx11.cmake")
+


### PR DESCRIPTION
add toolchain crosscompiling from linux to windows using mingw-w64, enabling gnu++11

I'm using this toolchain for ceres-solver mingw support (I'm trying to upgrade to hunter ceres-solver from 1.12 to 1.14 and additionally improve mingw support). Until now hunter ceres-solver with mingw only supports c++98. When enabling c++11 in mingw-w64 also `__STRICT_ANSI__` gets declared and the Bessel Functions `j0`, `j1`, `jn` are not defined by mingw-w64. With gnu++11 this problem isn't there

As a side note: As it seems the next ceres-solver (1.15) will require at least c++11 https://github.com/ceres-solver/ceres-solver/commit/282b8b5f35de02d653292c480796a1a53946c16c

I also did not enable `-static` for this toolchain. For me with ceres-solver I get multiple definitions of glibc functions when using the `-static` flag in the toolchain. I recommend to use the static flag only for executables (and maybe dynamic libraries, haven't tested that).
An example of the linker errors when using `-static`
```
[100%] Linking CXX executable ../bin/ellipse_approximation.exe
/usr/lib/gcc/x86_64-w64-mingw32/7.3-win32/libgcc_eh.a(unwind-seh.o):(.text+0xb0): multiple definition of `_Unwind_GetIP'
/usr/lib/gcc/x86_64-w64-mingw32/7.3-win32/libgcc_s.a(d000009.o):(.text+0x0): first defined here
/usr/lib/gcc/x86_64-w64-mingw32/7.3-win32/libgcc_eh.a(unwind-seh.o):(.text+0xc0): multiple definition of `_Unwind_GetIPInfo'
/usr/lib/gcc/x86_64-w64-mingw32/7.3-win32/libgcc_s.a(d000010.o):(.text+0x0): first defined here
/usr/lib/gcc/x86_64-w64-mingw32/7.3-win32/libgcc_eh.a(unwind-seh.o):(.text+0x3c0): multiple definition of `_Unwind_Resume'
/usr/lib/gcc/x86_64-w64-mingw32/7.3-win32/libgcc_s.a(d000015.o):(.text+0x0): first defined here
/usr/lib/gcc/x86_64-w64-mingw32/7.3-win32/libgcc_eh.a(unwind-seh.o):(.text+0x4e0): multiple definition of `_Unwind_Backtrace'
/usr/lib/gcc/x86_64-w64-mingw32/7.3-win32/libgcc_s.a(d000002.o):(.text+0x0): first defined here
collect2: error: ld returned 1 exit status
```