### PR TITLE
set HUNTER_JOBS_NUMBER if `--jobs` is specified

### DIFF
--- a/bin/polly.py
+++ b/bin/polly.py
@@ -409,6 +409,9 @@ if local_install:
 if cpack_generator:
   generate_command.append('-DCPACK_GENERATOR={}'.format(cpack_generator))
 
+if args.jobs:
+  generate_command.append('-DHUNTER_JOBS_NUMBER={}'.format(args.jobs))
+
 if args.fwd != None:
   for x in args.fwd:
     generate_command.append("-D{}".format(x))


### PR DESCRIPTION
my ceres-solver builds with gcc-7 are getting killed. I suspect, that the system gets out of memory
https://travis-ci.org/NeroBurner/hunter/jobs/380620039#L2658

I tried to set `--jobs` variable in `jenkins.py` https://github.com/NeroBurner/hunter/commit/b224d059b96220dd4e9aa7ad4f5ab163a100f10b
but the dependencies built by Hunter are still using `-j32`
Edit: line showing `-j32` https://travis-ci.org/NeroBurner/hunter/jobs/380620039#L2075