### PR TITLE
Support OS X Command Line tools without Xcode

### DIFF
--- a/os/osx.cmake
+++ b/os/osx.cmake
@@ -52,9 +52,22 @@ if(_is_empty)
   endif()
 endif()
 
+# With a full Xcode install, typically `xcode-select -print-path` is something like:
+#     /Applications/Xcode.app/Contents/Developer
+#
+# But with just Xcode command line tools installed, the path is:
+#     /Library/Developer/CommandLineTools
+#
+# In the CommandLineTools case, the SDKs folder is at a different relative path.
+if(XCODE_DEVELOPER_ROOT MATCHES ".*CommandLineTools.*")
+    set(SDK_RELATIVE_PATH "SDKs")
+else()
+    set(SDK_RELATIVE_PATH "Platforms/MacOSX.platform/Developer/SDKs")
+endif()
+
 set(
     CMAKE_OSX_SYSROOT
-    "${XCODE_DEVELOPER_ROOT}/Platforms/MacOSX.platform/Developer/SDKs/MacOSX${OSX_SDK_VERSION}.sdk"
+    "${XCODE_DEVELOPER_ROOT}/${SDK_RELATIVE_PATH}/MacOSX${OSX_SDK_VERSION}.sdk"
     CACHE STRING "System root for OSX" FORCE
 )
 

--- a/os/osx.cmake
+++ b/os/osx.cmake
@@ -52,12 +52,6 @@ if(_is_empty)
   endif()
 endif()
 
-if(XCODE_DEVELOPER_ROOT MATCHES ".*CommandLineTools.*")
-    set(SDK_RELATIVE_PATH "SDKs")
-else()
-    set(SDK_RELATIVE_PATH "Platforms/MacOSX.platform/Developer/SDKs")
-endif()
-
 set(
     CMAKE_OSX_SYSROOT
     "${XCODE_DEVELOPER_ROOT}/Platforms/MacOSX.platform/Developer/SDKs/MacOSX${OSX_SDK_VERSION}.sdk"

--- a/os/osx.cmake
+++ b/os/osx.cmake
@@ -52,13 +52,6 @@ if(_is_empty)
   endif()
 endif()
 
-# With a full Xcode install, typically `xcode-select -print-path` is something like:
-#     /Applications/Xcode.app/Contents/Developer
-#
-# But with just Xcode command line tools installed, the path is:
-#     /Library/Developer/CommandLineTools
-#
-# In the CommandLineTools case, the SDKs folder is at a different relative path.
 if(XCODE_DEVELOPER_ROOT MATCHES ".*CommandLineTools.*")
     set(SDK_RELATIVE_PATH "SDKs")
 else()
@@ -67,9 +60,24 @@ endif()
 
 set(
     CMAKE_OSX_SYSROOT
-    "${XCODE_DEVELOPER_ROOT}/${SDK_RELATIVE_PATH}/MacOSX${OSX_SDK_VERSION}.sdk"
+    "${XCODE_DEVELOPER_ROOT}/Platforms/MacOSX.platform/Developer/SDKs/MacOSX${OSX_SDK_VERSION}.sdk"
     CACHE STRING "System root for OSX" FORCE
 )
+
+# With a full Xcode install, typically `xcode-select -print-path` is something like:
+#     /Applications/Xcode.app/Contents/Developer
+#
+# But with just Xcode command line tools installed, the path is:
+#     /Library/Developer/CommandLineTools
+#
+# In the CommandLineTools case, the SDKs folder is at a different relative path.
+if(NOT EXISTS "${CMAKE_OSX_SYSROOT}")
+  set(
+      CMAKE_OSX_SYSROOT
+      "${XCODE_DEVELOPER_ROOT}/SDKs/MacOSX${OSX_SDK_VERSION}.sdk"
+      CACHE STRING "System root for OSX" FORCE
+  )
+endif()
 
 if(NOT EXISTS "${CMAKE_OSX_SYSROOT}")
   polly_fatal_error("${CMAKE_OSX_SYSROOT} not exists")

--- a/os/osx.cmake
+++ b/os/osx.cmake
@@ -53,9 +53,8 @@ if(_is_empty)
 endif()
 
 set(
-    CMAKE_OSX_SYSROOT
+    __osx_sysroot_suggestion_1
     "${XCODE_DEVELOPER_ROOT}/Platforms/MacOSX.platform/Developer/SDKs/MacOSX${OSX_SDK_VERSION}.sdk"
-    CACHE STRING "System root for OSX" FORCE
 )
 
 # With a full Xcode install, typically `xcode-select -print-path` is something like:
@@ -65,14 +64,21 @@ set(
 #     /Library/Developer/CommandLineTools
 #
 # In the CommandLineTools case, the SDKs folder is at a different relative path.
-if(NOT EXISTS "${CMAKE_OSX_SYSROOT}")
-  set(
-      CMAKE_OSX_SYSROOT
-      "${XCODE_DEVELOPER_ROOT}/SDKs/MacOSX${OSX_SDK_VERSION}.sdk"
-      CACHE STRING "System root for OSX" FORCE
-  )
+set(
+    __osx_sysroot_suggestion_2
+    "${XCODE_DEVELOPER_ROOT}/SDKs/MacOSX${OSX_SDK_VERSION}.sdk"
+)
+
+if(EXISTS "${__osx_sysroot_suggestion_1}")
+  set(__osx_sysroot "${__osx_sysroot_suggestion_1}")
+elseif(EXISTS "${__osx_sysroot_suggestion_2}")
+  set(__osx_sysroot "${__osx_sysroot_suggestion_2}")
+else()
+  polly_fatal_error("OS X SDK does not exist at ${__osx_sysroot_suggestion_1} or ${__osx_sysroot_suggestion_2}")
 endif()
 
-if(NOT EXISTS "${CMAKE_OSX_SYSROOT}")
-  polly_fatal_error("${CMAKE_OSX_SYSROOT} not exists")
-endif()
+set(
+    CMAKE_OSX_SYSROOT
+    "${__osx_sysroot}"
+    CACHE STRING "System root for OSX" FORCE
+)


### PR DESCRIPTION
The current script sets the developer root by doing `xcode-select --print-path`. I have one machine with Xcode installed, and one with just the command line tools installed, no Xcode. 

On the machine with Xcode:
```
$ xcode-select --print-path
/Applications/Xcode.app/Contents/Developer
```

And if I ask for the SDK path:
```
$ xcrun --sdk macosx --show-sdk-path
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.14.sdk
```

And on the machine with just command line tools:
```
$ xcode-select --print-path
/Library/Developer/CommandLineTools
```

And the SDK path:
```
$ xcrun --sdk macosx --show-sdk-path
/Library/Developer/CommandLineTools/SDKs/MacOSX10.14.sdk
```

To support these setups, this change adds a case for when the root is in the command line tools directory.

Note: We *may* be able to just use `xcrun`, without having to add hardcoded strings to the end of `xcode-select --print-path`. But I'm not entirely sure

PTAL @ruslo 