### PR TITLE
Suggestion to add --output_filter option

### DIFF
--- a/bin/detail/generate_command.py
+++ b/bin/detail/generate_command.py
@@ -7,7 +7,7 @@ import sys
 
 import detail.call
 
-def run(generate_command, build_dir, polly_temp_dir, reconfig, logging):
+def run(generate_command, build_dir, polly_temp_dir, reconfig, logging, output_filter=None):
   if not os.path.exists(polly_temp_dir):
     os.makedirs(polly_temp_dir)
   saved_arguments_path = os.path.join(polly_temp_dir, 'saved-arguments')
@@ -18,7 +18,7 @@ def run(generate_command, build_dir, polly_temp_dir, reconfig, logging):
   )
 
   if reconfig or not os.path.exists(saved_arguments_path):
-    detail.call.call(generate_command, logging, cache_file=cache_file, sleep=1)
+    detail.call.call(generate_command, logging, cache_file=cache_file, sleep=1, output_filter=output_filter)
     open(saved_arguments_path, 'w').write(generate_command_oneline)
     return
 

--- a/bin/polly.py
+++ b/bin/polly.py
@@ -428,7 +428,7 @@ timer = detail.timer.Timer()
 
 timer.start('Generate')
 detail.generate_command.run(
-    generate_command, build_dir, polly_temp_dir, args.reconfig, logging
+    generate_command, build_dir, polly_temp_dir, args.reconfig, logging, args.output_filter
 )
 timer.stop()
 

--- a/bin/polly.py
+++ b/bin/polly.py
@@ -207,6 +207,11 @@ parser.add_argument(
 )
 
 parser.add_argument(
+    '--output_filter',
+    help="Output filter"
+)
+
+parser.add_argument(
     '--timeout',
     type=PositiveInt,
     help='Timeout for CTest'
@@ -476,7 +481,7 @@ if not args.nobuild:
     ]
     detail.call.call(zero_check_command, logging, sleep=1)
 
-  detail.call.call(build_command, logging, sleep=1)
+  detail.call.call(build_command, logging, sleep=1, output_filter=args.output_filter)
   timer.stop()
 
   if args.archive:


### PR DESCRIPTION
This PR is just a suggestion, feel free to close it if it's not desired.
The adds `--output_filter` option to specify what program to use to filter output(input from stdin, output stdout and stderr, like shell piping).

The "filter" is applied to handle `generate` and `build` command output. The log file will have "transformed" output.


See the discussion in #311.

-----
Example usage: [xcpretty](https://travis-ci.org/insufficientchocolate/github-client-cpp/builds/502604748#L169)
The output format is decided by the "filter program" though.
