### PR TITLE
Add a --dry-run option

### DIFF
--- a/bin/detail/call.py
+++ b/bin/detail/call.py
@@ -86,7 +86,7 @@ def teed_call(cmd_args, logging, output_filter=None):
 
   return p.wait()
 
-def call(call_args, logging, cache_file='', ignore=False, sleep=0, output_filter=None):
+def call(call_args, logging, cache_file='', ignore=False, sleep=0, output_filter=None, dry_run=False):
   pretty = 'Execute command: [\n'
   for i in call_args:
     pretty += '  `{}`\n'.format(i)
@@ -102,6 +102,9 @@ def call(call_args, logging, cache_file='', ignore=False, sleep=0, output_filter
   if logging.verbosity != 'silent':
     print(oneline)
   logging.write(oneline)
+
+  if dry_run:
+      sys.exit(0)
 
   x = teed_call(call_args, logging, output_filter)
   if x == 0 or ignore:

--- a/bin/detail/generate_command.py
+++ b/bin/detail/generate_command.py
@@ -7,7 +7,7 @@ import sys
 
 import detail.call
 
-def run(generate_command, build_dir, polly_temp_dir, reconfig, logging, output_filter=None):
+def run(generate_command, build_dir, polly_temp_dir, reconfig, logging, output_filter=None, dry_run=False):
   if not os.path.exists(polly_temp_dir):
     os.makedirs(polly_temp_dir)
   saved_arguments_path = os.path.join(polly_temp_dir, 'saved-arguments')
@@ -18,7 +18,7 @@ def run(generate_command, build_dir, polly_temp_dir, reconfig, logging, output_f
   )
 
   if reconfig or not os.path.exists(saved_arguments_path):
-    detail.call.call(generate_command, logging, cache_file=cache_file, sleep=1, output_filter=output_filter)
+    detail.call.call(generate_command, logging, cache_file=cache_file, sleep=1, output_filter=output_filter, dry_run=dry_run)
     open(saved_arguments_path, 'w').write(generate_command_oneline)
     return
 

--- a/bin/polly.py
+++ b/bin/polly.py
@@ -232,6 +232,12 @@ parser.add_argument(
     help="CTest binary (ctest or ctest3)"
 )
 
+parser.add_argument(
+    '--dry-run',
+    action='store_true',
+    help="Print the corresponding CMake command and quit"
+)
+
 args = parser.parse_args()
 
 polly_toolchain = detail.toolchain_name.get(args.toolchain)
@@ -428,7 +434,7 @@ timer = detail.timer.Timer()
 
 timer.start('Generate')
 detail.generate_command.run(
-    generate_command, build_dir, polly_temp_dir, args.reconfig, logging, args.output_filter
+    generate_command, build_dir, polly_temp_dir, args.reconfig, logging, args.output_filter, args.dry_run
 )
 timer.stop()
 


### PR DESCRIPTION
Add a --dry-run option, similar in nature to common Linux shell
scripts.  If this flag is specified, polly will create the generate
command, print it to the log and stdout, and then quit.
This allows one to use familiar polly one-liners to create
equivalent CMake generate commands.  This can be convenient
for a number of reasons, such as troubleshooting builds or creating
toolchain configurations for CMake friendly IDE's.  This provides
a convenient alternative to starting a build, killing it (ctrl-c)
and then grepping the log.