### PR TITLE
Don't force i386 for --iossim

### DIFF
--- a/bin/polly.py
+++ b/bin/polly.py
@@ -172,7 +172,7 @@ parser.add_argument(
 parser.add_argument(
     '--iossim',
     action='store_true',
-    help="Build for ios i386 simulator"
+    help="Build for ios simulator"
 )
 
 parser.add_argument(
@@ -454,8 +454,6 @@ build_command += target.args()
 build_command.append('--')
 
 if args.iossim:
-  build_command.append('-arch')
-  build_command.append('i386')
   build_command.append('-sdk')
   build_command.append('iphonesimulator')
 


### PR DESCRIPTION
i386 isn't available for iossimulator SDK 11.0+ so it shouldn't be forced.