### PR TITLE
Add cxx17 support for iOS and macOS 10.15 toolchains

### DIFF
--- a/bin/detail/toolchain_table.py
+++ b/bin/detail/toolchain_table.py
@@ -743,6 +743,7 @@ if platform.system() == 'Darwin':
       Toolchain('osx-10-14-cxx14', 'Xcode', osx_version='10.14'),
       Toolchain('osx-10-14-cxx17', 'Xcode', osx_version='10.14'),
       Toolchain('osx-10-15', 'Xcode', osx_version='10.15'),
+      Toolchain('osx-10-15-cxx17', 'Xcode', osx_version='10.15'),
       Toolchain('osx-10-15-dep-10-10', 'Xcode', osx_version='10.15'),
       Toolchain('osx-10-15-dep-10-10-cxx14', 'Xcode', osx_version='10.15'),
       Toolchain('osx-10-15-dep-10-10-cxx17', 'Xcode', osx_version='10.15'),

--- a/bin/detail/toolchain_table.py
+++ b/bin/detail/toolchain_table.py
@@ -513,6 +513,7 @@ if platform.system() == 'Linux':
 if platform.system() == 'Darwin':
   toolchain_table += [
       Toolchain('ios', 'Xcode'),
+      Toolchain('ios-cxx17', 'Xcode'),
       Toolchain('ios-bitcode', 'Xcode'),
       Toolchain('ios-13-2-dep-9-3-arm64-bitcode', 'Xcode', ios_version='13.2'),
       Toolchain('ios-13-0-dep-9-3-arm64', 'Xcode', ios_version='13.0'),

--- a/ios-cxx17.cmake
+++ b/ios-cxx17.cmake
@@ -1,0 +1,48 @@
+# Copyright (c) 2016, Ruslan Baratov
+# All rights reserved.
+
+if(DEFINED POLLY_IOS_CMAKE_)
+  return()
+else()
+  set(POLLY_IOS_CMAKE_ 1)
+endif()
+
+include("${CMAKE_CURRENT_LIST_DIR}/utilities/polly_module_path.cmake")
+include(polly_clear_environment_variables)
+include(polly_init)
+include("${CMAKE_CURRENT_LIST_DIR}/os/iphone-default-sdk.cmake") # -> IOS_SDK_VERSION
+
+set(POLLY_XCODE_COMPILER "clang")
+polly_init(
+  "iOS ${IOS_SDK_VERSION} Universal (iphoneos + iphonesimulator) / \
+${POLLY_XCODE_COMPILER} / \
+c++17 support"
+  "Xcode"
+)
+
+include(polly_common)
+include(polly_fatal_error)
+
+# # Fix try_compile
+include(polly_ios_bundle_identifier)
+set(CMAKE_MACOSX_BUNDLE YES)
+
+set(CMAKE_XCODE_ATTRIBUTE_CODE_SIGN_IDENTITY "iPhone Developer")
+
+# 32 bits support was dropped from iPhoneSdk11.0
+if(IOS_SDK_VERSION VERSION_LESS "11.0")
+  set(IPHONEOS_ARCHS armv7;armv7s;arm64)
+  set(IPHONESIMULATOR_ARCHS i386;x86_64)
+else()
+  polly_status_debug("iPhone11.0+ SDK detected, forcing 64 bits builds.")
+  set(IPHONEOS_ARCHS arm64)
+  set(IPHONESIMULATOR_ARCHS x86_64)
+endif()
+
+include("${CMAKE_CURRENT_LIST_DIR}/compiler/xcode.cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/os/iphone.cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/flags/cxx17.cmake")
+
+if(NOT IOS_SDK_VERSION VERSION_LESS 10.0)
+  include(polly_ios_development_team)
+endif()

--- a/osx-10-15-cxx17.cmake
+++ b/osx-10-15-cxx17.cmake
@@ -1,0 +1,29 @@
+# Copyright (c) 2018, Ruslan Baratov
+# All rights reserved.
+
+if(DEFINED POLLY_OSX_10_15_CMAKE_)
+  return()
+else()
+  set(POLLY_OSX_10_15_CMAKE_ 1)
+endif()
+
+include("${CMAKE_CURRENT_LIST_DIR}/utilities/polly_init.cmake")
+
+set(OSX_SDK_VERSION "10.15")
+set(POLLY_XCODE_COMPILER "clang")
+polly_init(
+    "Xcode (OS X ${OSX_SDK_VERSION}) / \
+${POLLY_XCODE_COMPILER} / \
+LLVM Standard C++ Library (libc++) / c++17 support"
+    "Xcode"
+)
+
+include("${CMAKE_CURRENT_LIST_DIR}/utilities/polly_common.cmake")
+
+include("${CMAKE_CURRENT_LIST_DIR}/compiler/xcode.cmake")
+
+set(CMAKE_OSX_DEPLOYMENT_TARGET "10.15" CACHE STRING "OS X Deployment target" FORCE)
+
+include("${CMAKE_CURRENT_LIST_DIR}/library/std/libcxx.cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/flags/cxx17.cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/os/osx.cmake")


### PR DESCRIPTION
This PR adds cxx17 support for general iOS and macOS 10.15 toolchains.