### PR TITLE
Fix macOS 11.0 toolchains

### DIFF
--- a/bin/detail/toolchain_table.py
+++ b/bin/detail/toolchain_table.py
@@ -819,9 +819,9 @@ if platform.system() == 'Darwin':
       Toolchain('osx-10-15-dep-10-10-cxx14', 'Xcode', osx_version='10.15'),
       Toolchain('osx-10-15-dep-10-10-cxx17', 'Xcode', osx_version='10.15'),
       Toolchain('osx-10-15-dep-10-12-cxx17', 'Xcode', osx_version='10.15'),
-      Toolchain('osx-11-0', 'Xcode', osx_version='10.16'),
-      Toolchain('osx-11-0-cxx17', 'Xcode', osx_version='10.16'),
-      Toolchain('osx-11-0-dep-10-10-cxx17', 'Xcode', osx_version='10.16'),
+      Toolchain('osx-11-0', 'Xcode', osx_version='11.0'),
+      Toolchain('osx-11-0-cxx17', 'Xcode', osx_version='11.0'),
+      Toolchain('osx-11-0-dep-10-10-cxx17', 'Xcode', osx_version='11.0'),
       Toolchain('linux-gcc-x64', 'Unix Makefiles'),
   ]
 

--- a/bin/detail/toolchain_table.py
+++ b/bin/detail/toolchain_table.py
@@ -819,9 +819,9 @@ if platform.system() == 'Darwin':
       Toolchain('osx-10-15-dep-10-10-cxx14', 'Xcode', osx_version='10.15'),
       Toolchain('osx-10-15-dep-10-10-cxx17', 'Xcode', osx_version='10.15'),
       Toolchain('osx-10-15-dep-10-12-cxx17', 'Xcode', osx_version='10.15'),
-      Toolchain('osx-10-16', 'Xcode', osx_version='10.16'),
-      Toolchain('osx-10-16-cxx17', 'Xcode', osx_version='10.16'),
-      Toolchain('osx-10-16-dep-10-10-cxx17', 'Xcode', osx_version='10.16'),
+      Toolchain('osx-11-0', 'Xcode', osx_version='10.16'),
+      Toolchain('osx-11-0-cxx17', 'Xcode', osx_version='10.16'),
+      Toolchain('osx-11-0-dep-10-10-cxx17', 'Xcode', osx_version='10.16'),
       Toolchain('linux-gcc-x64', 'Unix Makefiles'),
   ]
 

--- a/osx-11-0-cxx17.cmake
+++ b/osx-11-0-cxx17.cmake
@@ -1,15 +1,15 @@
 # Copyright (c) 2018, Ruslan Baratov
 # All rights reserved.
 
-if(DEFINED POLLY_OSX_10_16_CMAKE_)
+if(DEFINED POLLY_OSX_11_0_CXX17_CMAKE_)
   return()
 else()
-  set(POLLY_OSX_10_16_CMAKE_ 1)
+  set(POLLY_OSX_11_0_CXX17_CMAKE_ 1)
 endif()
 
 include("${CMAKE_CURRENT_LIST_DIR}/utilities/polly_init.cmake")
 
-set(OSX_SDK_VERSION "10.16")
+set(OSX_SDK_VERSION "11.0")
 set(POLLY_XCODE_COMPILER "clang")
 polly_init(
     "Xcode (OS X ${OSX_SDK_VERSION}) / \
@@ -22,7 +22,7 @@ include("${CMAKE_CURRENT_LIST_DIR}/utilities/polly_common.cmake")
 
 include("${CMAKE_CURRENT_LIST_DIR}/compiler/xcode.cmake")
 
-set(CMAKE_OSX_DEPLOYMENT_TARGET "10.16" CACHE STRING "OS X Deployment target" FORCE)
+set(CMAKE_OSX_DEPLOYMENT_TARGET "11.0" CACHE STRING "OS X Deployment target" FORCE)
 
 include("${CMAKE_CURRENT_LIST_DIR}/library/std/libcxx.cmake")
 include("${CMAKE_CURRENT_LIST_DIR}/flags/cxx17.cmake")

--- a/osx-11-0-dep-10-10-cxx17.cmake
+++ b/osx-11-0-dep-10-10-cxx17.cmake
@@ -1,15 +1,15 @@
 # Copyright (c) 2016, Ruslan Baratov
 # All rights reserved.
 
-if(DEFINED POLLY_OSX_10_16_DEP_10_10_CXX17_CMAKE_)
+if(DEFINED POLLY_OSX_11_0_DEP_10_10_CXX17_CMAKE_)
   return()
 else()
-  set(POLLY_OSX_10_16_DEP_10_10_CXX17_CMAKE_ 1)
+  set(POLLY_OSX_11_0_DEP_10_10_CXX17_CMAKE_ 1)
 endif()
 
 include("${CMAKE_CURRENT_LIST_DIR}/utilities/polly_init.cmake")
 
-set(OSX_SDK_VERSION "10.16")
+set(OSX_SDK_VERSION "11.0")
 set(POLLY_XCODE_COMPILER "clang")
 polly_init(
     "Xcode (OS X ${OSX_SDK_VERSION} | Deployment 10.10) / \

--- a/osx-11-0.cmake
+++ b/osx-11-0.cmake
@@ -1,15 +1,15 @@
 # Copyright (c) 2018, Ruslan Baratov
 # All rights reserved.
 
-if(DEFINED POLLY_OSX_10_16_CMAKE_)
+if(DEFINED POLLY_OSX_11_0_CMAKE_)
   return()
 else()
-  set(POLLY_OSX_10_16_CMAKE_ 1)
+  set(POLLY_OSX_11_0_CMAKE_ 1)
 endif()
 
 include("${CMAKE_CURRENT_LIST_DIR}/utilities/polly_init.cmake")
 
-set(OSX_SDK_VERSION "10.16")
+set(OSX_SDK_VERSION "11.0")
 set(POLLY_XCODE_COMPILER "clang")
 polly_init(
     "Xcode (OS X ${OSX_SDK_VERSION}) / \
@@ -22,7 +22,7 @@ include("${CMAKE_CURRENT_LIST_DIR}/utilities/polly_common.cmake")
 
 include("${CMAKE_CURRENT_LIST_DIR}/compiler/xcode.cmake")
 
-set(CMAKE_OSX_DEPLOYMENT_TARGET "10.16" CACHE STRING "OS X Deployment target" FORCE)
+set(CMAKE_OSX_DEPLOYMENT_TARGET "11.0" CACHE STRING "OS X Deployment target" FORCE)
 
 include("${CMAKE_CURRENT_LIST_DIR}/library/std/libcxx.cmake")
 include("${CMAKE_CURRENT_LIST_DIR}/flags/cxx11.cmake")


### PR DESCRIPTION
Apple ended the 10.x series and went to 11.0 so these toolchain files
are incorrect.